### PR TITLE
Add test coverage for auth flows, error states, and models

### DIFF
--- a/spec/lib/cache_spec.rb
+++ b/spec/lib/cache_spec.rb
@@ -41,6 +41,18 @@ describe Cache do
     end
   end
 
+  describe '.get_by_id with corrupt file' do
+    it 'returns nil and deletes the corrupt file' do
+      Cache.set_by_id(@session_id, bad: 'data')
+      path = File.join(Cache::SHARED_DIR, "#{@session_id}_bad.json")
+      File.write(path, 'not valid json{{{')
+
+      result = Cache.get_by_id(@session_id, :bad)
+      assert_nil result
+      refute File.exist?(path), 'Expected corrupt cache file to be deleted'
+    end
+  end
+
   describe '.cleanup_stale' do
     it 'removes files older than 1 hour' do
       Cache.set_by_id(@session_id, old: 'data')

--- a/spec/lib/models_spec.rb
+++ b/spec/lib/models_spec.rb
@@ -7,6 +7,7 @@ Sequel.extension :migration
 Sequel::Migrator.run(DB, 'db/migrations')
 
 require 'models/account'
+require 'models/bookmooch_import'
 require 'models/goodreads_connection'
 
 describe Account do
@@ -104,6 +105,78 @@ describe GoodreadsConnection do
       assert_instance_of OAuth::AccessToken, token
       assert_equal 'my_token', token.token
       assert_equal 'my_secret', token.secret
+    end
+  end
+end
+
+describe BookmoochImport do
+  before do
+    DB.run('PRAGMA foreign_keys = OFF')
+    DB.tables.each { |t| DB[t].delete }
+    DB.run('PRAGMA foreign_keys = ON')
+    @account = Account.create(email: "test_bm_#{rand(1_000_000)}@example.com", password_hash: 'hash', status_id: 2)
+  end
+
+  describe '.already_imported_isbns' do
+    it 'returns a set of imported ISBNs for the user' do
+      BookmoochImport.create(user_id: @account.id, isbn: '111')
+      BookmoochImport.create(user_id: @account.id, isbn: '222')
+      result = BookmoochImport.already_imported_isbns(@account.id)
+      assert_instance_of Set, result
+      assert_includes result, '111'
+      assert_includes result, '222'
+    end
+
+    it 'returns empty set when no imports exist' do
+      result = BookmoochImport.already_imported_isbns(@account.id)
+      assert_empty result
+    end
+
+    it 'does not include ISBNs from other users' do
+      other = Account.create(email: "other_#{rand(1_000_000)}@example.com", password_hash: 'hash', status_id: 2)
+      BookmoochImport.create(user_id: other.id, isbn: '999')
+      result = BookmoochImport.already_imported_isbns(@account.id)
+      refute_includes result, '999'
+    end
+  end
+
+  describe '.record_imports' do
+    it 'inserts new import records' do
+      books = [{isbn: '111', bookmooch_isbn: '111'}, {isbn: '222', bookmooch_isbn: '333'}]
+      BookmoochImport.record_imports(@account.id, books, shelf_name: 'read')
+      assert_equal 2, BookmoochImport.where(user_id: @account.id).count
+    end
+
+    it 'skips books with nil or empty ISBN' do
+      books = [{isbn: nil}, {isbn: ''}, {isbn: '111', bookmooch_isbn: '111'}]
+      BookmoochImport.record_imports(@account.id, books, shelf_name: 'read')
+      assert_equal 1, BookmoochImport.where(user_id: @account.id).count
+    end
+
+    it 'updates existing records on conflict instead of duplicating' do
+      BookmoochImport.create(user_id: @account.id, isbn: '111', shelf_name: 'to-read')
+      books = [{isbn: '111', bookmooch_isbn: '111'}]
+      BookmoochImport.record_imports(@account.id, books, shelf_name: 'read')
+      assert_equal 1, BookmoochImport.where(user_id: @account.id).count
+      assert_equal 'read', BookmoochImport.where(user_id: @account.id, isbn: '111').first[:shelf_name]
+    end
+  end
+
+  describe '.clear_imports' do
+    it 'deletes all imports for the user' do
+      BookmoochImport.create(user_id: @account.id, isbn: '111')
+      BookmoochImport.create(user_id: @account.id, isbn: '222')
+      BookmoochImport.clear_imports(@account.id)
+      assert_equal 0, BookmoochImport.where(user_id: @account.id).count
+    end
+
+    it 'does not delete imports for other users' do
+      other = Account.create(email: "other2_#{rand(1_000_000)}@example.com", password_hash: 'hash', status_id: 2)
+      BookmoochImport.create(user_id: @account.id, isbn: '111')
+      BookmoochImport.create(user_id: other.id, isbn: '222')
+      BookmoochImport.clear_imports(@account.id)
+      assert_equal 0, BookmoochImport.where(user_id: @account.id).count
+      assert_equal 1, BookmoochImport.where(user_id: other.id).count
     end
   end
 end

--- a/spec/web/auth_spec.rb
+++ b/spec/web/auth_spec.rb
@@ -39,6 +39,9 @@ describe 'Authentication flows' do
       fill_in 'Password', with: new_password
       click_button 'Reset Password'
 
+      # Should redirect to login page after successful reset
+      assert_text 'has been reset'
+
       # Log in with the new password
       password_login(email, new_password)
       assert_text 'Welcome back,'

--- a/spec/web/auth_spec.rb
+++ b/spec/web/auth_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+describe 'Authentication flows' do
+  include Capybara::DSL
+  include Minitest::Capybara::Behaviour
+  include Rack::Test::Methods
+
+  let :app do
+    App
+  end
+
+  describe 'password reset' do
+    it 'completes the full password reset flow' do
+      email, = create_account_direct
+      new_password = 'NewSecurePassword456!'
+
+      # Request password reset
+      visit '/reset-password-request'
+      fill_in 'Email', with: email
+      click_button 'Send Password Reset Email'
+
+      assert_text 'password reset link'
+
+      # Build the reset URL from the database key
+      account = DB[:accounts].where(email: email).first
+      key_row = nil
+      10.times do
+        key_row = DB[:account_password_reset_keys].where(id: account[:id]).first
+        break if key_row
+
+        sleep 0.1
+      end
+      assert key_row, 'Expected password reset key to be created'
+
+      # Visit the reset link and set new password
+      visit "/reset-password?key=#{account[:id]}_#{key_row[:key]}"
+      fill_in 'Password', with: new_password
+      click_button 'Reset Password'
+
+      # Log in with the new password
+      password_login(email, new_password)
+      assert_text 'Welcome back,'
+    end
+
+    it 'shows error for non-existent email on password reset request' do
+      visit '/reset-password-request'
+      fill_in 'Email', with: 'nobody_exists@example.com'
+      click_button 'Send Password Reset Email'
+
+      assert_text 'error'
+    end
+  end
+
+  describe 'account lockout' do
+    it 'locks account after max failed login attempts' do
+      email, password = create_account_direct
+
+      # Simulate 9 failed logins via DB (avoids slow Capybara visits)
+      account = DB[:accounts].where(email: email).first
+      DB[:account_login_failures].insert(id: account[:id], number: 9)
+
+      # One more failed attempt triggers lockout creation
+      visit '/authenticate'
+      within('#password-login-form') do
+        fill_in 'Email', with: email
+        fill_in 'Password', with: 'WrongPassword!'
+        click_button 'Log In with Password'
+      end
+
+      # Verify lockout record exists in database
+      lockout = DB[:account_lockouts].where(id: account[:id]).first
+      assert lockout, 'Expected account lockout record to exist'
+
+      # Now try with correct password - should still be locked
+      visit '/authenticate'
+      within('#password-login-form') do
+        fill_in 'Email', with: email
+        fill_in 'Password', with: password
+        click_button 'Log In with Password'
+      end
+
+      assert_text(/locked|unlock/i)
+    end
+  end
+
+  describe 'session expiration' do
+    it 'redirects to login after session expires' do
+      get '/home'
+      assert last_response.redirect?
+      assert_includes last_response.headers['Location'], '/authenticate'
+    end
+  end
+end

--- a/spec/web/auth_spec.rb
+++ b/spec/web/auth_spec.rb
@@ -62,25 +62,20 @@ describe 'Authentication flows' do
       DB[:account_login_failures].insert(id: account[:id], number: 9)
 
       # One more failed attempt triggers lockout creation
-      visit '/authenticate'
-      within('#password-login-form') do
-        fill_in 'Email', with: email
-        fill_in 'Password', with: 'WrongPassword!'
-        click_button 'Log In with Password'
-      end
+      password_login(email, 'WrongPassword!')
+      assert_text 'invalid password'
 
-      # Verify lockout record exists in database
+      # Wait for DB write to complete, then verify lockout
+      sleep 0.5
+      failures = DB[:account_login_failures].where(id: account[:id]).first
+      assert failures, 'Expected login failures record'
+      assert failures[:number] >= 10, "Expected number >= 10, got #{failures[:number]}"
+
       lockout = DB[:account_lockouts].where(id: account[:id]).first
       assert lockout, 'Expected account lockout record to exist'
 
       # Now try with correct password - should still be locked
-      visit '/authenticate'
-      within('#password-login-form') do
-        fill_in 'Email', with: email
-        fill_in 'Password', with: password
-        click_button 'Log In with Password'
-      end
-
+      password_login(email, password)
       assert_text(/locked|unlock/i)
     end
   end

--- a/spec/web/email_auth_spec.rb
+++ b/spec/web/email_auth_spec.rb
@@ -26,7 +26,6 @@ describe 'Magic link and email auth' do
     assert_text 'spam or promotions'
     assert_link 'Resend verification email'
     assert_link 'Log in'
-    sleep 2
   end
 
   it 'shows the login page with magic link as primary and password as fallback' do
@@ -40,24 +39,15 @@ describe 'Magic link and email auth' do
     assert_button 'Log In with Password'
     assert_link 'Forgot password?'
     assert_link 'Sign up'
-    sleep 2
   end
 
   it 'sends a magic link email when requesting email auth' do
-    fake_email = "test_magiclink_#{Time.now.to_i}@example.com"
-    fake_password = 'SecurePassword123!'
-
-    # Create and verify an account first
-    visit '/sign-up'
-    fill_in 'Email', with: fake_email
-    fill_in 'Password', with: fake_password
-    click_button 'Create Account'
-    verify_account(fake_email)
+    email, = create_account_direct
 
     # Request a magic link
     visit '/authenticate'
     within('#magic-link-form') do
-      fill_in 'Email', with: fake_email
+      fill_in 'Email', with: email
       click_button 'Send Me a Login Link'
     end
 
@@ -65,33 +55,24 @@ describe 'Magic link and email auth' do
     assert_text 'Check your email for a login link'
 
     # Verify the email auth key was created in the database
-    account = DB[:accounts].where(email: fake_email).first
+    account = DB[:accounts].where(email: email).first
     key_row = DB[:account_email_auth_keys].where(id: account[:id]).first
     assert key_row, 'Expected email_auth_key to be created'
     assert key_row[:key], 'Expected key to have a value'
-    sleep 2
   end
 
   it 'logs in via magic link token' do
-    fake_email = "test_magictoken_#{Time.now.to_i}@example.com"
-    fake_password = 'SecurePassword123!'
-
-    # Create and verify an account
-    visit '/sign-up'
-    fill_in 'Email', with: fake_email
-    fill_in 'Password', with: fake_password
-    click_button 'Create Account'
-    verify_account(fake_email)
+    email, = create_account_direct
 
     # Request a magic link
     visit '/authenticate'
     within('#magic-link-form') do
-      fill_in 'Email', with: fake_email
+      fill_in 'Email', with: email
       click_button 'Send Me a Login Link'
     end
 
     # Build the magic link URL from the database key (wait for async creation)
-    account = DB[:accounts].where(email: fake_email).first
+    account = DB[:accounts].where(email: email).first
     key_row = nil
     10.times do
       key_row = DB[:account_email_auth_keys].where(id: account[:id]).first
@@ -106,14 +87,13 @@ describe 'Magic link and email auth' do
 
     # Should be logged in and redirected to home
     assert_text 'Welcome back,'
-    sleep 2
   end
 
   it 'verifies account and auto-logs in when clicking verification link' do
     fake_email = "test_autologin_#{Time.now.to_i}@example.com"
     fake_password = 'SecurePassword123!'
 
-    # Create account (unverified)
+    # Create account (unverified) - must use UI to generate verification key
     visit '/sign-up'
     fill_in 'Email', with: fake_email
     fill_in 'Password', with: fake_password
@@ -136,6 +116,5 @@ describe 'Magic link and email auth' do
 
     # Should be auto-logged in and redirected to home (verify_account_autologin? true)
     assert_text 'Welcome back,'
-    sleep 2
   end
 end

--- a/spec/web/error_states_spec.rb
+++ b/spec/web/error_states_spec.rb
@@ -58,7 +58,8 @@ describe 'Error states' do
     password_login(email, password)
 
     visit '/goodreads/shelves'
-    assert_text 'Please connect your Goodreads account first'
+    # Should redirect to /goodreads connect page (flash may auto-dismiss)
+    assert_text 'Connect Goodreads'
   end
 
   it 'handles /connections without auth gracefully' do
@@ -81,9 +82,9 @@ describe 'Error states' do
     email, password = create_account_direct
     password_login(email, password)
 
-    # Add a Goodreads connection directly
+    # Add a Goodreads connection with timestamps
     account = DB[:accounts].where(email: email).first
-    DB[:goodreads_connections].insert(user_id: account[:id], goodreads_user_id: 'gr_test_disconnect', access_token: 'tok', access_token_secret: 'sec')
+    add_goodreads_connection(account[:id], 'gr_test_disconnect', 'tok', 'sec')
 
     assert DB[:goodreads_connections].where(user_id: account[:id]).any?
 

--- a/spec/web/error_states_spec.rb
+++ b/spec/web/error_states_spec.rb
@@ -24,24 +24,16 @@ describe 'Error states' do
   end
 
   it 'shows error for wrong password login' do
-    fake_email = "test_wrongpw_#{Time.now.to_i}@example.com"
-    fake_password = 'SecurePassword123!'
-
-    visit '/sign-up'
-    fill_in 'Email', with: fake_email
-    fill_in 'Password', with: fake_password
-    click_button 'Create Account'
-    verify_account(fake_email)
+    email, = create_account_direct
 
     visit '/authenticate'
     within('#password-login-form') do
-      fill_in 'Email', with: fake_email
+      fill_in 'Email', with: email
       fill_in 'Password', with: 'WrongPassword999!'
       click_button 'Log In with Password'
     end
 
     assert_text 'invalid password'
-    sleep 2
   end
 
   it 'shows error for non-existent account login' do
@@ -53,7 +45,6 @@ describe 'Error states' do
     end
 
     assert_text 'No account exists with that email'
-    sleep 2
   end
 
   it 'returns ok from health endpoint' do
@@ -63,18 +54,57 @@ describe 'Error states' do
   end
 
   it 'redirects to connect goodreads when accessing shelves without connection' do
-    fake_email = "test_noshelves_#{Time.now.to_i}@example.com"
-    fake_password = 'SecurePassword123!'
-
-    visit '/sign-up'
-    fill_in 'Email', with: fake_email
-    fill_in 'Password', with: fake_password
-    click_button 'Create Account'
-    verify_account(fake_email)
-    password_login(fake_email, fake_password)
+    email, password = create_account_direct
+    password_login(email, password)
 
     visit '/goodreads/shelves'
     assert_text 'Please connect your Goodreads account first'
-    sleep 2
+  end
+
+  it 'handles /connections without auth gracefully' do
+    visit '/connections'
+    assert page.has_text?('Yonderbook')
+  end
+
+  it 'shows check-email page with fallback when no pending email in session' do
+    get '/check-email'
+    assert last_response.ok?
+    assert_includes last_response.body, 'your email'
+  end
+
+  it 'redirects to root for unknown routes under /goodreads' do
+    get '/goodreads/nonexistent'
+    refute_equal 500, last_response.status
+  end
+
+  it 'disconnects Goodreads connection for authenticated user' do
+    email, password = create_account_direct
+    password_login(email, password)
+
+    # Add a Goodreads connection directly
+    account = DB[:accounts].where(email: email).first
+    DB[:goodreads_connections].insert(user_id: account[:id], goodreads_user_id: 'gr_test_disconnect', access_token: 'tok', access_token_secret: 'sec')
+
+    assert DB[:goodreads_connections].where(user_id: account[:id]).any?
+
+    # Visit account page and disconnect (accept confirmation dialog)
+    visit '/account'
+    accept_confirm do
+      click_button 'Disconnect Goodreads'
+    end
+
+    assert_text 'removed'
+    refute DB[:goodreads_connections].where(user_id: account[:id]).any?
+  end
+
+  it 'redirects from /libraries without auth' do
+    get '/libraries'
+    assert last_response.redirect?
+  end
+
+  it 'redirects from /goodreads/availability when no titles cached' do
+    seed_goodreads_user
+    visit '/goodreads/availability'
+    assert_text 'Please choose a shelf first'
   end
 end

--- a/spec/web/spec_helper.rb
+++ b/spec/web/spec_helper.rb
@@ -92,20 +92,21 @@ module TestHelpers
     DB[:account_verification_keys].where(id: account[:id]).delete
   end
 
+  # Create a verified account directly in the DB (fast, no browser round-trip).
+  # Returns [email, password].
+  def create_account_direct
+    require 'argon2'
+    email = "test_#{Time.now.to_i}_#{rand(9999)}@example.com"
+    password = 'SecurePassword123!'
+    hash = Argon2::Password.new(t_cost: 1, m_cost: 5).create(password)
+    DB[:accounts].insert(email: email, password_hash: hash, status_id: 2)
+    [email, password]
+  end
+
   # Create a verified account with Goodreads connected, then log in via browser.
   # Returns the account id.
   def seed_goodreads_user
-    email = "test_gr_#{Time.now.to_i}_#{rand(9999)}@example.com"
-    password = 'SecurePassword123!'
-
-    # Create account through the UI (so the server connection owns the row)
-    visit '/'
-    click_link 'Sign Up'
-    fill_in 'Email', with: email
-    fill_in 'Confirm Email', with: email if page.has_field?('Confirm Email')
-    fill_in 'Password', with: password
-    click_button 'Create Account'
-    verify_account(email)
+    email, password = create_account_direct
 
     # Look up account and add Goodreads connection
     account = DB[:accounts].where(email: email).first

--- a/spec/web/spec_helper.rb
+++ b/spec/web/spec_helper.rb
@@ -103,6 +103,20 @@ module TestHelpers
     [email, password]
   end
 
+  # Insert a Goodreads connection with required timestamps (raw insert skips model hooks)
+  def add_goodreads_connection user_id, goodreads_user_id, token, secret
+    now = Time.now
+    DB[:goodreads_connections].insert(
+      user_id: user_id,
+      goodreads_user_id: goodreads_user_id,
+      access_token: token,
+      access_token_secret: secret,
+      connected_at: now,
+      created_at: now,
+      updated_at: now
+    )
+  end
+
   # Create a verified account with Goodreads connected, then log in via browser.
   # Returns the account id.
   def seed_goodreads_user
@@ -110,12 +124,7 @@ module TestHelpers
 
     # Look up account and add Goodreads connection
     account = DB[:accounts].where(email: email).first
-    DB[:goodreads_connections].insert(
-      user_id: account[:id],
-      goodreads_user_id: ENV.fetch('GOODREADS_USER_ID'),
-      access_token: ENV.fetch('GOODREADS_ACCESS_TOKEN'),
-      access_token_secret: ENV.fetch('GOODREADS_ACCESS_TOKEN_SECRET')
-    )
+    add_goodreads_connection(account[:id], ENV.fetch('GOODREADS_USER_ID'), ENV.fetch('GOODREADS_ACCESS_TOKEN'), ENV.fetch('GOODREADS_ACCESS_TOKEN_SECRET'))
 
     # Log in via the browser
     password_login(email, password)

--- a/spec/web/system_spec.rb
+++ b/spec/web/system_spec.rb
@@ -104,28 +104,11 @@ describe App do
     assert_link 'Account'
     refute_link 'Login'
     refute_link 'Sign Up'
-    sleep 2 # Give Selenium time to clean up session before next test
   end
 
   it 'connects Goodreads via OAuth and browses shelves' do
-    fake_email = "test_goodreads_user_#{Time.now.to_i}@example.com"
-    fake_password = 'SecurePassword123!'
-
-    # First create a Rodauth account
-    visit '/'
-    click_link 'Sign Up'
-    fill_in 'Email', with: fake_email
-    fill_in 'Confirm Email', with: fake_email if page.has_field?('Confirm Email')
-    fill_in 'Password', with: fake_password
-    click_button 'Create Account'
-
-    # Manually verify the account so the user can log in
-    verify_account(fake_email)
-
-    # Log in with the verified account
+    fake_email, fake_password = create_account_direct
     password_login(fake_email, fake_password)
-
-    # Should be redirected to home page
     assert_text 'Welcome back,'
 
     # Try to connect with Goodreads - OAuth flow requires 3 attempts to bypass Amazon CVF
@@ -159,7 +142,6 @@ describe App do
     # Final visit to get OAuth tokens
     visit '/goodreads/shelves'
     assert_text 'Choose a shelf'
-    sleep 2
   end
 
   it 'shows shelf stats for a seeded Goodreads user' do
@@ -170,7 +152,6 @@ describe App do
     all(:link, 'Stats')[2].click
     sleep 10
     assert_text 'Publication Years'
-    sleep 2
   end
 
   it 'searches OverDrive libraries for a seeded Goodreads user' do
@@ -187,7 +168,6 @@ describe App do
     click_on 'Unavailable'
     sleep 1
     assert_text 'Unavailable'
-    sleep 2
   end
 
   it 'shows BookMooch on the connections page with education and Goodreads requirement' do
@@ -205,28 +185,17 @@ describe App do
 
     # Should land on shelves page in bookmooch mode
     assert_text 'Choose a shelf'
-    sleep 2
   end
 
   it 'shows BookMooch requires Goodreads when not connected' do
-    fake_email = "test_bm_#{Time.now.to_i}@example.com"
-    fake_password = 'SecurePassword123!'
-
-    visit '/'
-    click_link 'Sign Up'
-    fill_in 'Email', with: fake_email
-    fill_in 'Confirm Email', with: fake_email if page.has_field?('Confirm Email')
-    fill_in 'Password', with: fake_password
-    click_button 'Create Account'
-    verify_account(fake_email)
-    password_login(fake_email, fake_password)
+    email, password = create_account_direct
+    password_login(email, password)
 
     visit '/connections'
 
     # BookMooch card should be visible but indicate Goodreads is needed
     assert_text 'BookMooch'
     assert_text 'Connect Goodreads first'
-    sleep 2
   end
 
   it 'imports books to BookMooch via connections page' do
@@ -252,6 +221,5 @@ describe App do
       sleep 120
       assert_text 'Success!'
     end
-    sleep 2
   end
 end


### PR DESCRIPTION
- Password reset flow (end-to-end)
- Account lockout after max failed logins
- Goodreads disconnect
- Route error paths (unauthenticated redirects, check-email fallback)
- BookmoochImport model (record_imports, clear_imports, already_imported_isbns)
- Cache corrupt JSON handling
- Direct DB account creation helper for faster tests
- Remove unnecessary sleep calls across test suite