### PR TITLE
Progressive auth foundation: exchange_token + session helpers

### DIFF
--- a/lib/goodreads.rb
+++ b/lib/goodreads.rb
@@ -115,10 +115,7 @@ module Goodreads
     end
   end
 
-  def fetch_user request_token, yonderbook_user_id
-    access_token = request_token.get_access_token
-    goodreads_token = access_token.token
-    goodreads_secret = access_token.secret
+  def fetch_goodreads_user_id access_token
     uri = new_uri
     uri.path = '/api/auth_user'
     response = access_token.get uri.to_s
@@ -129,10 +126,19 @@ module Goodreads
     user_id = user_node['id']
     raise 'Goodreads API response missing user id attribute' unless user_id
 
-    # Save Goodreads connection to database
-    save_goodreads_connection(yonderbook_user_id, user_id, goodreads_token, goodreads_secret)
+    user_id
+  end
 
-    [user_id, goodreads_token, goodreads_secret]
+  def exchange_token request_token
+    access_token = request_token.get_access_token
+    user_id = fetch_goodreads_user_id(access_token)
+    {user_id: user_id, token: access_token.token, secret: access_token.secret}
+  end
+
+  def fetch_user request_token, yonderbook_user_id
+    credentials = exchange_token(request_token)
+    save_goodreads_connection(yonderbook_user_id, credentials[:user_id], credentials[:token], credentials[:secret])
+    [credentials[:user_id], credentials[:token], credentials[:secret]]
   end
 
   def save_goodreads_connection yonderbook_user_id, user_id, token, secret

--- a/lib/route_helpers.rb
+++ b/lib/route_helpers.rb
@@ -17,6 +17,30 @@ module RouteHelpers
     load_goodreads_connection
   end
 
+  def store_goodreads_in_session credentials
+    Cache.set session,
+      anon_goodreads_user_id: credentials[:user_id],
+      anon_goodreads_token: credentials[:token],
+      anon_goodreads_secret: credentials[:secret]
+  end
+
+  def load_goodreads_from_session
+    @goodreads_user_id = Cache.get(session, :anon_goodreads_user_id)
+    token = Cache.get(session, :anon_goodreads_token)
+    secret = Cache.get(session, :anon_goodreads_secret)
+    return false unless @goodreads_user_id && token && secret
+
+    @anon_access_token = Auth.rebuild_access_token(token, secret)
+    true
+  end
+
+  def require_goodreads_session request
+    return if load_goodreads_from_session
+
+    flash[:error] = 'Please connect your Goodreads account first'
+    request.redirect '/'
+  end
+
   def load_goodreads_connection
     @goodreads_connection = @user.goodreads_connection
     @goodreads_user_id = @goodreads_connection.goodreads_user_id

--- a/lib/route_helpers.rb
+++ b/lib/route_helpers.rb
@@ -18,13 +18,10 @@ module RouteHelpers
   end
 
   def store_goodreads_in_session credentials
-    Cache.set session,
-      anon_goodreads_user_id: credentials[:user_id],
-      anon_goodreads_token: credentials[:token],
-      anon_goodreads_secret: credentials[:secret]
+    Cache.set(session, anon_goodreads_user_id: credentials[:user_id], anon_goodreads_token: credentials[:token], anon_goodreads_secret: credentials[:secret])
   end
 
-  def load_goodreads_from_session
+  def goodreads_session_present?
     @goodreads_user_id = Cache.get(session, :anon_goodreads_user_id)
     token = Cache.get(session, :anon_goodreads_token)
     secret = Cache.get(session, :anon_goodreads_secret)
@@ -35,7 +32,7 @@ module RouteHelpers
   end
 
   def require_goodreads_session request
-    return if load_goodreads_from_session
+    return if goodreads_session_present?
 
     flash[:error] = 'Please connect your Goodreads account first'
     request.redirect '/'

--- a/spec/lib/goodreads_spec.rb
+++ b/spec/lib/goodreads_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'spec_helper'
+require 'auth'
 require 'goodreads'
 
 describe Goodreads do
@@ -53,6 +54,26 @@ describe Goodreads do
       books = [{rating: '4', ratings: nil}]
       stats = Goodreads.rating_stats(books)
       assert_equal 1, stats[4]
+    end
+  end
+
+  describe '.exchange_token' do
+    it 'is defined as a module method' do
+      assert_respond_to Goodreads, :exchange_token
+    end
+  end
+
+  describe '.fetch_goodreads_user_id' do
+    it 'is defined as a module method' do
+      assert_respond_to Goodreads, :fetch_goodreads_user_id
+    end
+  end
+
+  describe '.fetch_user' do
+    it 'delegates to exchange_token internally' do
+      # fetch_user should call exchange_token then save_goodreads_connection.
+      # We verify the method signature is preserved: it accepts (request_token, yonderbook_user_id)
+      assert_equal 2, Goodreads.method(:fetch_user).arity
     end
   end
 

--- a/spec/lib/route_helpers_spec.rb
+++ b/spec/lib/route_helpers_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+require 'auth'
+require 'cache'
+require 'route_helpers'
+
+describe RouteHelpers do
+  # Create a minimal test class that includes RouteHelpers,
+  # simulating the Roda app context with session and flash.
+  let(:helper) do
+    klass = Class.new do
+      include RouteHelpers
+      attr_accessor :session
+
+      def flash
+        @flash ||= {}
+      end
+    end
+    obj = klass.new
+    obj.session = {'session_id' => "test_#{rand(99999)}"}
+    obj
+  end
+
+  describe '#store_goodreads_in_session' do
+    it 'stores user_id, token, and secret in the cache' do
+      credentials = {user_id: '12345', token: 'tok_abc', secret: 'sec_xyz'}
+      helper.store_goodreads_in_session(credentials)
+
+      assert_equal '12345', Cache.get(helper.session, :anon_goodreads_user_id)
+      assert_equal 'tok_abc', Cache.get(helper.session, :anon_goodreads_token)
+      assert_equal 'sec_xyz', Cache.get(helper.session, :anon_goodreads_secret)
+    end
+  end
+
+  describe '#load_goodreads_from_session' do
+    it 'returns true and sets instance variables when credentials are cached' do
+      Cache.set(helper.session,
+        anon_goodreads_user_id: '12345',
+        anon_goodreads_token: 'tok_abc',
+        anon_goodreads_secret: 'sec_xyz')
+
+      result = helper.load_goodreads_from_session
+
+      assert result
+      assert_equal '12345', helper.instance_variable_get(:@goodreads_user_id)
+      assert_kind_of OAuth::AccessToken, helper.instance_variable_get(:@anon_access_token)
+    end
+
+    it 'returns false when credentials are missing' do
+      result = helper.load_goodreads_from_session
+      refute result
+    end
+  end
+
+  describe '#require_goodreads_session' do
+    it 'does not redirect when session credentials exist' do
+      Cache.set(helper.session,
+        anon_goodreads_user_id: '12345',
+        anon_goodreads_token: 'tok_abc',
+        anon_goodreads_secret: 'sec_xyz')
+
+      # If it doesn't raise/redirect, the guard passed
+      request = Minitest::Mock.new
+      helper.require_goodreads_session(request)
+
+      assert_equal '12345', helper.instance_variable_get(:@goodreads_user_id)
+    end
+  end
+end

--- a/spec/lib/route_helpers_spec.rb
+++ b/spec/lib/route_helpers_spec.rb
@@ -11,6 +11,7 @@ describe RouteHelpers do
   let(:helper) do
     klass = Class.new do
       include RouteHelpers
+
       attr_accessor :session
 
       def flash
@@ -18,7 +19,7 @@ describe RouteHelpers do
       end
     end
     obj = klass.new
-    obj.session = {'session_id' => "test_#{rand(99999)}"}
+    obj.session = {'session_id' => "test_#{rand(99_999)}"}
     obj
   end
 
@@ -33,14 +34,11 @@ describe RouteHelpers do
     end
   end
 
-  describe '#load_goodreads_from_session' do
+  describe '#goodreads_session_present?' do
     it 'returns true and sets instance variables when credentials are cached' do
-      Cache.set(helper.session,
-        anon_goodreads_user_id: '12345',
-        anon_goodreads_token: 'tok_abc',
-        anon_goodreads_secret: 'sec_xyz')
+      Cache.set(helper.session, anon_goodreads_user_id: '12345', anon_goodreads_token: 'tok_abc', anon_goodreads_secret: 'sec_xyz')
 
-      result = helper.load_goodreads_from_session
+      result = helper.goodreads_session_present?
 
       assert result
       assert_equal '12345', helper.instance_variable_get(:@goodreads_user_id)
@@ -48,19 +46,15 @@ describe RouteHelpers do
     end
 
     it 'returns false when credentials are missing' do
-      result = helper.load_goodreads_from_session
+      result = helper.goodreads_session_present?
       refute result
     end
   end
 
   describe '#require_goodreads_session' do
     it 'does not redirect when session credentials exist' do
-      Cache.set(helper.session,
-        anon_goodreads_user_id: '12345',
-        anon_goodreads_token: 'tok_abc',
-        anon_goodreads_secret: 'sec_xyz')
+      Cache.set(helper.session, anon_goodreads_user_id: '12345', anon_goodreads_token: 'tok_abc', anon_goodreads_secret: 'sec_xyz')
 
-      # If it doesn't raise/redirect, the guard passed
       request = Minitest::Mock.new
       helper.require_goodreads_session(request)
 


### PR DESCRIPTION
## Summary
- Extract `exchange_token` and `fetch_goodreads_user_id` from `Goodreads.fetch_user` so OAuth token exchange works without database persistence
- Add session-based credential helpers to `RouteHelpers`: `store_goodreads_in_session`, `load_goodreads_from_session`, `require_goodreads_session`
- `fetch_user` refactored to call `exchange_token` internally — same external contract, no behavior change

## Test plan
- [x] `Goodreads.exchange_token` method exists and is callable
- [x] `Goodreads.fetch_goodreads_user_id` method exists and is callable
- [x] `Goodreads.fetch_user` arity preserved (2 args)
- [x] `store_goodreads_in_session` writes all 3 credential keys to Cache
- [x] `load_goodreads_from_session` reads credentials and builds OAuth::AccessToken
- [x] `load_goodreads_from_session` returns false when credentials missing
- [x] `require_goodreads_session` passes when credentials exist
- [x] All existing specs pass (no regressions)

Closes #1252, closes #1253, closes #1254