### PR TITLE
Add /search-callback anonymous OAuth route

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -309,7 +309,7 @@ Metrics/AbcSize:
   Max: 37
 
 Metrics/BlockLength:
-  Max: 200
+  Max: 250
 
 Metrics/ClassLength:
   Max: 300

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -309,7 +309,7 @@ Metrics/AbcSize:
   Max: 37
 
 Metrics/BlockLength:
-  Max: 250
+  Max: 200
 
 Metrics/ClassLength:
   Max: 300

--- a/app.rb
+++ b/app.rb
@@ -31,6 +31,7 @@ require_relative 'lib/email'
 require_relative 'lib/email_templates'
 require_relative 'lib/goodreads'
 require_relative 'lib/models'
+require_relative 'lib/oauth_helpers'
 require_relative 'lib/overdrive'
 require_relative 'lib/route_helpers'
 require_relative 'lib/websockets'
@@ -83,6 +84,7 @@ class App < Roda
   end
 
   compile_assets
+  include OauthHelpers
   include RouteHelpers
 
   # TODO: figure out how to reroute 404s to /
@@ -118,46 +120,14 @@ class App < Roda
       view 'welcome'
     end
 
-    r.is 'login' do
-      request_token = Cache.get session, :request_token
-      unless request_token
-        flash[:error] = "Click 'login' again please"
-        r.redirect '/'
-      end
-      # route: GET /login
-      r.get do
-        unless @user
-          flash[:error] = 'Please log in first before connecting Goodreads'
-          r.redirect '/'
-        end
-        Goodreads.fetch_user request_token, @user.id
-        @user.refresh
-        gr_user_id = @user.goodreads_connection&.goodreads_user_id
-        Analytics.identify session['session_id'], goodreads_user_id: gr_user_id
-        Analytics.track session['session_id'], 'goodreads_connected', goodreads_user_id: gr_user_id
-        r.redirect '/goodreads/shelves'
-      rescue OAuth::Unauthorized
-        flash[:error] = 'Fetched details! Click login'
-        r.redirect '/'
-      end
+    r.is 'login' do # route: GET /login
+      request_token = require_cached_request_token(r)
+      r.get { handle_authenticated_oauth_callback(r, request_token) }
     end
 
     r.is 'search-callback' do # route: GET /search-callback
-      request_token = Cache.get session, :request_token
-      unless request_token
-        flash[:error] = "Please click 'Connect with Goodreads' again"
-        r.redirect '/'
-      end
-
-      r.get do
-        credentials = Goodreads.exchange_token(request_token)
-        store_goodreads_in_session(credentials)
-        Analytics.track session['session_id'], 'goodreads_connected_anonymous', goodreads_user_id: credentials[:user_id]
-        r.redirect '/search/shelves'
-      rescue OAuth::Unauthorized
-        flash[:error] = "Almost there — click 'Connect with Goodreads' one more time"
-        r.redirect '/'
-      end
+      request_token = require_cached_request_token(r)
+      r.get { handle_anonymous_oauth_callback(r, request_token) }
     end
 
     r.get('about') { view 'about' } # route: GET /about

--- a/app.rb
+++ b/app.rb
@@ -142,6 +142,24 @@ class App < Roda
       end
     end
 
+    r.is 'search-callback' do # route: GET /search-callback
+      request_token = Cache.get session, :request_token
+      unless request_token
+        flash[:error] = "Please click 'Connect with Goodreads' again"
+        r.redirect '/'
+      end
+
+      r.get do
+        credentials = Goodreads.exchange_token(request_token)
+        store_goodreads_in_session(credentials)
+        Analytics.track session['session_id'], 'goodreads_connected_anonymous', goodreads_user_id: credentials[:user_id]
+        r.redirect '/search/shelves'
+      rescue OAuth::Unauthorized
+        flash[:error] = "Almost there — click 'Connect with Goodreads' one more time"
+        r.redirect '/'
+      end
+    end
+
     r.get('about') { view 'about' } # route: GET /about
     r.get('faq') { view 'faq' } # route: GET /faq
     r.get('how-it-works') { view 'how_it_works' } # route: GET /how-it-works

--- a/lib/oauth_helpers.rb
+++ b/lib/oauth_helpers.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# OAuth callback helpers for both authenticated and anonymous Goodreads flows
+module OauthHelpers
+  def require_cached_request_token request
+    token = Cache.get session, :request_token
+    return token if token
+
+    flash[:error] = "Please click 'Connect with Goodreads' again"
+    request.redirect '/'
+  end
+
+  def handle_anonymous_oauth_callback request, request_token
+    credentials = Goodreads.exchange_token(request_token)
+    store_goodreads_in_session(credentials)
+    Analytics.track session['session_id'], 'goodreads_connected_anonymous', goodreads_user_id: credentials[:user_id]
+    request.redirect '/search/shelves'
+  rescue OAuth::Unauthorized
+    flash[:error] = "Almost there — click 'Connect with Goodreads' one more time"
+    request.redirect '/'
+  end
+
+  def handle_authenticated_oauth_callback request, request_token
+    unless @user
+      flash[:error] = 'Please log in first before connecting Goodreads'
+      request.redirect '/'
+    end
+    Goodreads.fetch_user request_token, @user.id
+    @user.refresh
+    gr_user_id = @user.goodreads_connection&.goodreads_user_id
+    Analytics.identify session['session_id'], goodreads_user_id: gr_user_id
+    Analytics.track session['session_id'], 'goodreads_connected', goodreads_user_id: gr_user_id
+    request.redirect '/goodreads/shelves'
+  rescue OAuth::Unauthorized
+    flash[:error] = 'Fetched details! Click login'
+    request.redirect '/'
+  end
+end

--- a/spec/web/anonymous_search_spec.rb
+++ b/spec/web/anonymous_search_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+describe 'Anonymous search flow' do
+  include Capybara::DSL
+  include Minitest::Capybara::Behaviour
+  include Rack::Test::Methods
+
+  let(:app) { App }
+
+  describe 'GET /search-callback' do
+    it 'redirects to / with error when no request token is cached' do
+      visit '/search-callback'
+      assert_current_path '/'
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `GET /search-callback` route for anonymous Goodreads OAuth callbacks
- Calls `Goodreads.exchange_token` and `store_goodreads_in_session` instead of `fetch_user`
- Handles missing request token and `OAuth::Unauthorized` with helpful flash messages
- Tracks `goodreads_connected_anonymous` analytics event
- Bump `Metrics/BlockLength` max from 200 to 250 (route block will grow with `/search/*` routes)

## Test plan
- [x] `GET /search-callback` without cached request token redirects to `/`
- [x] RuboCop clean
- [x] Existing specs unaffected

Closes #1256