### PR TITLE
Add anonymous shelf routes and search/shelves view

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -34,6 +34,7 @@ require_relative 'lib/models'
 require_relative 'lib/oauth_helpers'
 require_relative 'lib/overdrive'
 require_relative 'lib/route_helpers'
+require_relative 'lib/search_routes'
 require_relative 'lib/websockets'
 
 SESSION_SECRET = ENV.fetch('SESSION_SECRET').then do |s|
@@ -86,6 +87,7 @@ class App < Roda
   compile_assets
   include OauthHelpers
   include RouteHelpers
+  include SearchRoutes
 
   # TODO: figure out how to reroute 404s to /
   route do |r|
@@ -129,6 +131,8 @@ class App < Roda
       request_token = require_cached_request_token(r)
       r.get { handle_anonymous_oauth_callback(r, request_token) }
     end
+
+    r.on('search') { handle_search_routes(r) }
 
     r.get('about') { view 'about' } # route: GET /about
     r.get('faq') { view 'faq' } # route: GET /faq

--- a/lib/search_routes.rb
+++ b/lib/search_routes.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Anonymous search routes for users who connected Goodreads without an account
+module SearchRoutes
+  def handle_search_routes request
+    require_goodreads_session request
+
+    request.on 'shelves' do
+      # route: GET /search/shelves
+      request.get true do
+        @shelves = Goodreads.fetch_shelves @goodreads_user_id
+        view 'search/shelves'
+      end
+
+      request.on String do |shelf_name|
+        @shelf_name = shelf_name
+        @book_info = cached_or_fetch(@shelf_name.to_sym) { Goodreads.get_books(@shelf_name, @goodreads_user_id, @anon_access_token) }
+
+        # route: GET /search/shelves/:name
+        request.get true do
+          @histogram_dataset = Goodreads.plot_books_over_time @book_info
+          @ratings = Goodreads.rating_stats @book_info
+          view 'shelves/show'
+        end
+      end
+    end
+  end
+end

--- a/spec/web/anonymous_search_spec.rb
+++ b/spec/web/anonymous_search_spec.rb
@@ -15,4 +15,11 @@ describe 'Anonymous search flow' do
       assert_current_path '/'
     end
   end
+
+  describe 'GET /search/shelves' do
+    it 'redirects to / when no session credentials exist' do
+      visit '/search/shelves'
+      assert_current_path '/'
+    end
+  end
 end

--- a/views/search/shelves.erb
+++ b/views/search/shelves.erb
@@ -1,0 +1,36 @@
+<% content_for :title, "Your Shelves" %>
+<% content_for :description, "Browse your Goodreads shelves. Select a shelf to analyze your reading or find free books at your library." %>
+
+<div class="max-w-4xl mx-auto mb-8">
+  <div class="text-center">
+    <h3 class="font-display text-2xl font-medium text-mauve-950 mb-4">Step 1</h3>
+    <div class="w-full bg-mauve-200 rounded-full h-2 mb-4">
+      <div class="bg-mauve-950 h-2 rounded-full w-1/4"></div>
+    </div>
+    <h5 class="text-xl font-medium text-mauve-700">Choose a shelf</h5>
+    <p class="text-sm text-mauve-500 mt-2">Pick a shelf to check library availability. "to-read" is usually what you want.</p>
+  </div>
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+  <% @shelves.sort_by { |_, count| -count }.each do |name, count| %>
+    <div class="rounded-xl bg-mauve-950/[.025] overflow-hidden">
+      <div class="p-6">
+        <h6 class="text-lg font-semibold text-mauve-950 mb-2"><%= name %></h6>
+        <p class="text-mauve-700"><%= count %> book<%= 's' if count != 1 %></p>
+      </div>
+      <div class="px-6 py-4 border-t border-mauve-950/10 flex justify-between items-center gap-2">
+        <% if count.positive? %>
+          <a class="inline-flex items-center px-4 py-2 bg-mauve-950 hover:bg-mauve-900 text-white text-sm font-medium rounded-full transition-colors duration-200" href="/search/shelves/<%= name %>">
+            <img src="/svg/chart-bar.svg" alt="" class="w-4 h-4 mr-2">
+            Stats
+          </a>
+          <a class="inline-flex items-center px-4 py-2 bg-mauve-950/10 hover:bg-mauve-950/20 text-mauve-950 text-sm font-medium rounded-full transition-colors duration-200" href="/search/shelves/<%= name %>/overdrive">
+            <img src="/svg/book.svg" alt="" class="w-4 h-4 mr-2">
+            Get Books
+          </a>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
## Summary
- Add `GET /search/shelves` — lists Goodreads shelves for anonymous users
- Add `GET /search/shelves/:name` — shows shelf stats (reuses existing `shelves/show.erb`)
- New `views/search/shelves.erb` — like `shelves/index.erb` but with `/search/` links and no BookMooch toggle
- Routes extracted to `lib/search_routes.rb` module to keep `route do` block under RuboCop's `BlockLength` limit

## Test plan
- [x] `GET /search/shelves` without session credentials redirects to `/`
- [x] `GET /search-callback` without request token redirects to `/`
- [x] RuboCop clean
- [x] All existing specs pass

Closes #1257, closes #1261