### PR TITLE
Fix homepage timeout: cache request token, add HTTP timeouts

### DIFF
--- a/lib/auth.rb
+++ b/lib/auth.rb
@@ -14,11 +14,14 @@ module Auth
   end
 
   def fetch_request_token
-    new_consumer.get_request_token
-  rescue Net::HTTPFatalError, Net::HTTPBadResponse, Net::OpenTimeout, Errno::EBADF, EOFError
+    consumer = new_consumer
+    consumer.http.open_timeout = 5
+    consumer.http.read_timeout = 5
+    consumer.get_request_token
+  rescue Net::HTTPFatalError, Net::HTTPBadResponse, Net::OpenTimeout, Net::ReadTimeout, Errno::EBADF, EOFError
     retries ||= 0
     retries += 1
-    retry if retries < 4
+    retry if retries < 3
   end
 
   def rebuild_access_token access_token, access_token_secret

--- a/lib/route_helpers.rb
+++ b/lib/route_helpers.rb
@@ -3,6 +3,9 @@
 # Route helper methods: import tracking, caching, Goodreads/BookMooch integration, Sentry
 module RouteHelpers
   def fetch_and_cache_request_token
+    cached = Cache.get(session, :request_token)
+    return cached if cached
+
     Auth.fetch_request_token.tap { |token| Cache.set(session, request_token: token) if token }
   rescue StandardError => e
     Sentry.capture_exception(e) if defined?(Sentry)


### PR DESCRIPTION
## Summary
`GET /` was timing out because `fetch_and_cache_request_token` fetched a new OAuth request token from Goodreads on **every** homepage load without checking the cache first. When Goodreads was slow (>25s), the request middleware timeout fired.

## Root causes
1. **No cache read** — `fetch_and_cache_request_token` wrote to cache but never read from it
2. **No HTTP timeouts** — OAuth consumer used Net::HTTP defaults (60s open, 60s read)
3. **Too many retries** — 4 retries × 60s = could block for 4 minutes

## Fixes
- Check `Cache.get(session, :request_token)` before calling Goodreads
- Set `open_timeout` and `read_timeout` to 5s on the OAuth consumer's HTTP client
- Reduce retries from 4 to 3 (max 15s total, well under 25s request timeout)
- Add `Net::ReadTimeout` to the rescue list

## Test plan
- [x] Existing specs pass
- [x] RuboCop clean
- [ ] Deploy and verify homepage loads without timeout