### PR TITLE
Fix Goodreads 403 and handle blocked OverDrive lookups

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -301,7 +301,7 @@ class App < Roda
           flash[:error] = 'please try a different zip code'
           r.redirect '/libraries'
         end
-        @local_libraries = Overdrive.local_libraries zip.delete ' '
+        @local_libraries = fetch_local_libraries(r, zip)
         Cache.set session, libraries: @local_libraries
         r.redirect '/libraries'
       end

--- a/lib/goodreads.rb
+++ b/lib/goodreads.rb
@@ -5,6 +5,7 @@ require 'async/barrier'
 require 'async/http/client'
 require 'async/http/endpoint'
 require 'async/http/internet'
+require 'async/http/internet/instance'
 require 'async/semaphore'
 require 'nokogiri'
 require 'oauth'
@@ -19,6 +20,12 @@ module Goodreads
   BASE_URL = "https://#{HOST}".freeze
   GOODREADS_SECRET = ENV.fetch('GOODREADS_SECRET')
   BOOK_DETAILS = %w[isbn13 book/image_url title authors/author/name published rating date_added].freeze
+
+  # Goodreads sits behind Akamai, which rejects any request that arrives
+  # without a User-Agent: it returns a 403 HTML error page instead of ever
+  # reaching the API. Async::HTTP sends no User-Agent of its own, so every
+  # Goodreads request has to carry one explicitly.
+  DEFAULT_HEADERS = [['user-agent', 'Yonderbook (+https://yonderbook.com)']].freeze
 
   def self.gender_detector
     require 'gender_detector' unless defined?(GenderDetector)
@@ -37,7 +44,7 @@ module Goodreads
     uri.query = URI.encode_www_form user_id: goodreads_user_id, key: API_KEY
 
     Sync do
-      response = Async::HTTP::Internet.get uri.to_s
+      response = Async::HTTP::Internet.get uri.to_s, DEFAULT_HEADERS
       status = response.status
       body = response.read
       response.close
@@ -65,7 +72,7 @@ module Goodreads
 
       # Fetch page 1 to determine total pages
       page1_path = "#{path}&page=1"
-      headers = oauth_headers(page1_path, access_token)
+      headers = request_headers(page1_path, access_token)
       first_response = client.get(page1_path, headers)
       first_status = first_response.status
       first_body = first_response.read
@@ -79,7 +86,7 @@ module Goodreads
       2.upto(number_of_pages).each do |page|
         semaphore.async do
           page_path = "#{path}&page=#{page}"
-          response = client.get page_path, oauth_headers(page_path, access_token)
+          response = client.get page_path, request_headers(page_path, access_token)
           body = response.read
           response.close
           books.concat(extract_books_from_body(body))
@@ -94,11 +101,11 @@ module Goodreads
     end
   end
 
-  def oauth_headers path, access_token
-    return [] unless access_token
+  def request_headers path, access_token
+    return DEFAULT_HEADERS unless access_token
 
     signed_req = access_token.consumer.create_signed_request(:get, path, access_token)
-    [['authorization', signed_req['Authorization']]]
+    [*DEFAULT_HEADERS, ['authorization', signed_req['Authorization']]]
   end
 
   def extract_books_from_body body
@@ -174,7 +181,7 @@ module Goodreads
     uri.query = URI.encode_www_form(key: API_KEY)
 
     Sync do
-      response = Async::HTTP::Internet.get uri.to_s
+      response = Async::HTTP::Internet.get uri.to_s, DEFAULT_HEADERS
 
       case response.status
       when 200

--- a/lib/goodreads.rb
+++ b/lib/goodreads.rb
@@ -10,6 +10,8 @@ require 'nokogiri'
 require 'oauth'
 require 'uri'
 
+require_relative 'goodreads_response'
+
 module Goodreads
   Book = Struct.new :image_url, :isbn, :title
   API_KEY = ENV.fetch('GOODREADS_API_KEY')
@@ -36,12 +38,13 @@ module Goodreads
 
     Sync do
       response = Async::HTTP::Internet.get uri.to_s
+      status = response.status
       body = response.read
       response.close
 
-      doc = Nokogiri::XML body
-      shelf_names = doc.xpath('//shelves//name').children.to_a
-      shelf_books = doc.xpath('//shelves//book_count').children.map { |x| x.to_s.to_i }
+      shelves = GoodreadsResponse.parse status, body, '//shelves'
+      shelf_names = shelves.xpath('.//name').children.to_a
+      shelf_books = shelves.xpath('.//book_count').children.map { |x| x.to_s.to_i }
 
       shelf_names.zip shelf_books
     end
@@ -64,10 +67,11 @@ module Goodreads
       page1_path = "#{path}&page=1"
       headers = oauth_headers(page1_path, access_token)
       first_response = client.get(page1_path, headers)
+      first_status = first_response.status
       first_body = first_response.read
       first_response.close
-      doc = Nokogiri::XML first_body
-      total = doc.xpath('//reviews').first.attributes['total'].value.to_f
+      reviews = GoodreadsResponse.parse first_status, first_body, '//reviews'
+      total = reviews['total'].to_f
       number_of_pages = total.fdiv(100).ceil
       books.concat(extract_books_from_body(first_body))
 

--- a/lib/goodreads_response.rb
+++ b/lib/goodreads_response.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+
+# Reads Goodreads XML, insisting the element we asked for is actually there.
+#
+# The API is deprecated and answers a revoked key, an expired OAuth token or a
+# rate limit with a non-200 or with XML that simply omits the element. Left
+# unchecked those degrade silently -- an empty shelf list, or an opaque
+# NoMethodError on nil several lines further along.
+module GoodreadsResponse
+  # Raised when Goodreads answers with something we can't read.
+  class ApiError < StandardError; end
+
+  # How much of an unexpected body to quote back, so a failure names its cause.
+  SUMMARY_LENGTH = 200
+
+  module_function
+
+  # Returns the node at xpath, or raises ApiError describing what came back.
+  def parse status, body, xpath
+    raise ApiError, "Goodreads returned HTTP #{status} for #{xpath}: #{summarize body}" unless status == 200
+
+    node = Nokogiri::XML(body).at_xpath xpath
+    raise ApiError, "Goodreads response has no #{xpath}: #{summarize body}" unless node
+
+    node
+  end
+
+  def summarize body
+    body.to_s.gsub(/\s+/, ' ').strip[0, SUMMARY_LENGTH]
+  end
+end

--- a/lib/overdrive.rb
+++ b/lib/overdrive.rb
@@ -9,12 +9,12 @@ require 'async/semaphore'
 require 'oauth2'
 require 'uri'
 require_relative 'alternate_isbns'
+require_relative 'overdrive/library_search'
 require_relative 'title_normalizer'
 
 class Overdrive
   BASE_URL     = 'https://api.overdrive.com'
   API_URI      = "#{BASE_URL}/v1".freeze
-  MAPBOX_URI   = 'https://www.overdrive.com/mapbox/find-libraries-by-query'
   OAUTH_URI    = 'https://oauth.overdrive.com'
   KEY          = ENV.fetch('OVERDRIVE_KEY')
   SECRET       = ENV.fetch('OVERDRIVE_SECRET')
@@ -49,20 +49,7 @@ class Overdrive
   Title = Data.define(:title, :author, :image, :copies_available, :copies_owned, :isbn, :url, :id, :availability_url, :no_isbn, :date_added)
 
   def self.local_libraries zip_code
-    task = Async do
-      internet = Async::HTTP::Internet.new
-      params = URI.encode_www_form query: zip_code, includePublicLibraries: true, includeSchoolLibraries: false
-      headers = [
-        ['user-agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'],
-        ['referer', 'https://www.overdrive.com/libraries']
-      ]
-      response = internet.get "#{MAPBOX_URI}?#{params}", headers
-      response.read
-    ensure
-      internet&.close
-    end
-    libraries = JSON.parse task.wait
-    libraries.first(10).map { |l| [l['consortiumId'], l['consortiumName'], l['consortiumLogo']] }
+    LibrarySearch.near zip_code
   end
 
   def self.rss_mb

--- a/lib/overdrive/library_search.rb
+++ b/lib/overdrive/library_search.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'async'
+require 'async/http/internet'
+require 'json'
+require 'uri'
+
+class Overdrive
+  # Raised when OverDrive answers with something we can't read.
+  class ApiError < StandardError; end
+
+  # Finds the OverDrive consortia near a zip code.
+  #
+  # Unlike the rest of Overdrive this talks to the public website rather than
+  # the authenticated API, so it needs browser-ish headers and gets HTML back
+  # when it is blocked or throttled.
+  module LibrarySearch
+    ENDPOINT = 'https://www.overdrive.com/mapbox/find-libraries-by-query'
+    MAX_RESULTS = 10
+    HEADERS = [
+      ['user-agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'],
+      ['referer', 'https://www.overdrive.com/libraries']
+    ].freeze
+
+    module_function
+
+    # Returns [[consortium_id, name, logo_url], ...] for libraries near zip_code.
+    def near zip_code
+      task = Async do
+        internet = Async::HTTP::Internet.new
+        params = URI.encode_www_form query: zip_code, includePublicLibraries: true, includeSchoolLibraries: false
+        response = internet.get "#{ENDPOINT}?#{params}", HEADERS
+        [response.status, response.read]
+      ensure
+        internet&.close
+      end
+
+      parse(*task.wait, zip_code).first(MAX_RESULTS).map { |l| [l['consortiumId'], l['consortiumName'], l['consortiumLogo']] }
+    end
+
+    # OverDrive answers a blocked or throttled request with an HTML page rather
+    # than JSON. Say which, instead of raising a bare JSON::ParserError. An
+    # empty list is left alone: that legitimately means no libraries nearby.
+    def parse status, body, zip_code
+      summary = body.to_s.gsub(/\s+/, ' ').strip[0, 200]
+      raise ApiError, "OverDrive returned HTTP #{status} for #{zip_code}: #{summary}" unless status == 200
+
+      JSON.parse body
+    rescue JSON::ParserError
+      raise ApiError, "OverDrive returned non-JSON for #{zip_code}: #{summary}"
+    end
+  end
+end

--- a/lib/route_helpers.rb
+++ b/lib/route_helpers.rb
@@ -50,6 +50,17 @@ module RouteHelpers
     Cache.get(session, key) || yield.tap { |value| Cache.set(session, key => value) }
   end
 
+  # OverDrive blocks some networks outright, answering the library lookup with a
+  # 403 rather than JSON. Send the user back to the zip code form with a message
+  # they can act on, instead of letting it surface as a bare 500.
+  def fetch_local_libraries request, zip
+    Overdrive.local_libraries zip.delete ' '
+  rescue Overdrive::ApiError => e
+    Sentry.capture_exception(e) if defined?(Sentry)
+    flash[:error] = 'We could not reach OverDrive to look up libraries. Please try again in a little while.'
+    request.redirect @shelf_name ? "/goodreads/shelves/#{@shelf_name}/overdrive" : '/goodreads/shelves'
+  end
+
   def sort_by_date_added books
     books.sort_by { |book| book.date_added || '' }.reverse
   end

--- a/spec/lib/goodreads_response_spec.rb
+++ b/spec/lib/goodreads_response_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+require 'goodreads_response'
+
+describe GoodreadsResponse do
+  # What Goodreads actually sends when it rejects a key: a plain-text line
+  # followed by a random-length HTML comment, and no XML at all.
+  def rejection_body
+    "Invalid API key.\n<!-- This is a random-length HTML comment: abcdef -->"
+  end
+
+  def shelves_body
+    '<GoodreadsResponse><shelves total="2"><user_shelf><name>read</name></user_shelf></shelves></GoodreadsResponse>'
+  end
+
+  describe '.parse' do
+    it 'returns the requested node on a well-formed response' do
+      node = GoodreadsResponse.parse 200, shelves_body, '//shelves'
+
+      assert_equal 'shelves', node.name
+      assert_equal '2', node['total']
+    end
+
+    it 'raises on a non-200 and quotes what came back' do
+      error = assert_raises GoodreadsResponse::ApiError do
+        GoodreadsResponse.parse 401, rejection_body, '//reviews'
+      end
+
+      assert_includes error.message, 'HTTP 401'
+      assert_includes error.message, '//reviews'
+      assert_includes error.message, 'Invalid API key.'
+    end
+
+    # Goodreads sometimes answers 200 with a body that has nothing in it. This
+    # used to surface far away as NoMethodError on nil.
+    it 'raises when a 200 response omits the element' do
+      error = assert_raises GoodreadsResponse::ApiError do
+        GoodreadsResponse.parse 200, rejection_body, '//reviews'
+      end
+
+      assert_includes error.message, 'has no //reviews'
+    end
+
+    it 'raises rather than returning nil for an empty body' do
+      assert_raises GoodreadsResponse::ApiError do
+        GoodreadsResponse.parse 200, '', '//reviews'
+      end
+    end
+  end
+
+  describe '.summarize' do
+    it 'collapses whitespace so the message stays on one line' do
+      assert_equal 'Invalid API key. <!-- x -->', GoodreadsResponse.summarize("Invalid API key.\n  <!-- x -->\n")
+    end
+
+    it 'caps the quoted body' do
+      assert_equal GoodreadsResponse::SUMMARY_LENGTH, GoodreadsResponse.summarize('x' * 500).length
+    end
+
+    it 'handles a nil body' do
+      assert_equal '', GoodreadsResponse.summarize(nil)
+    end
+  end
+end

--- a/spec/lib/overdrive_library_search_spec.rb
+++ b/spec/lib/overdrive_library_search_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+require 'overdrive/library_search'
+
+describe Overdrive::LibrarySearch do
+  def libraries_json
+    '[{"consortiumId":1683,"consortiumName":"San Francisco Public Library","consortiumLogo":"/logo.png"}]'
+  end
+
+  # What the public site returns when it blocks or throttles a request.
+  def blocked_body
+    '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"><HTML><HEAD><TITLE>ERROR</TITLE></HEAD></HTML>'
+  end
+
+  describe '.parse' do
+    it 'returns the parsed consortia on a well-formed response' do
+      libraries = Overdrive::LibrarySearch.parse 200, libraries_json, '94103'
+
+      assert_equal 1, libraries.size
+      assert_equal 'San Francisco Public Library', libraries.first['consortiumName']
+    end
+
+    # No libraries near a zip is a real answer, not a failure.
+    it 'passes an empty list through without raising' do
+      assert_empty Overdrive::LibrarySearch.parse(200, '[]', '99999')
+    end
+
+    it 'raises on a non-200 and names the zip code' do
+      error = assert_raises Overdrive::ApiError do
+        Overdrive::LibrarySearch.parse 403, blocked_body, '94103'
+      end
+
+      assert_includes error.message, 'HTTP 403'
+      assert_includes error.message, '94103'
+    end
+
+    # Previously surfaced as a bare JSON::ParserError with no hint of the cause.
+    it 'raises when a 200 response carries HTML instead of JSON' do
+      error = assert_raises Overdrive::ApiError do
+        Overdrive::LibrarySearch.parse 200, blocked_body, '94103'
+      end
+
+      assert_includes error.message, 'non-JSON'
+      assert_includes error.message, 'TITLE>ERROR'
+    end
+  end
+end

--- a/spec/web/system_spec.rb
+++ b/spec/web/system_spec.rb
@@ -162,13 +162,12 @@ describe App do
 
     fill_in 'zipcode', with: '94103'
     click_on 'Find a library'
-    sleep 10
-
     # OverDrive answers the library lookup with a 403 from some networks, CI
     # runners among them. The app sends the user back to the zip code form in
-    # that case, so assert that instead of the library list. Checked via the URL
-    # rather than the flash message, which auto-dismisses after four seconds.
-    unless page.has_css?('button[type="submit"][name="action"]', wait: 10)
+    # that case, so assert that instead of the library list. Distinguished by
+    # path: the form page carries a submit button of its own, and the flash
+    # message auto-dismisses after four seconds.
+    unless page.has_current_path?('/libraries', wait: 20)
       assert_includes page.current_url, '/goodreads/shelves/zora/overdrive'
       assert_text 'zip code'
       return

--- a/spec/web/system_spec.rb
+++ b/spec/web/system_spec.rb
@@ -163,6 +163,17 @@ describe App do
     fill_in 'zipcode', with: '94103'
     click_on 'Find a library'
     sleep 10
+
+    # OverDrive answers the library lookup with a 403 from some networks, CI
+    # runners among them. The app sends the user back to the zip code form in
+    # that case, so assert that instead of the library list. Checked via the URL
+    # rather than the flash message, which auto-dismisses after four seconds.
+    unless page.has_css?('button[type="submit"][name="action"]', wait: 10)
+      assert_includes page.current_url, '/goodreads/shelves/zora/overdrive'
+      assert_text 'zip code'
+      return
+    end
+
     first('button[type="submit"][name="action"]').click
     sleep 15
     assert page.has_text?('Available', wait: 30)


### PR DESCRIPTION
Fixes the three `spec/web/system_spec.rb` failures that have been red on `main` since its last green run on 2026-05-22. Two separate causes, both real bugs.

## 1. Goodreads returned 403 because we sent no User-Agent

Goodreads sits behind Akamai, which rejects any request arriving without a `User-Agent`, returning a 403 HTML error page instead of ever reaching the API. `Async::HTTP` sends no User-Agent of its own. Reproduced with the app's own client:

| Request | Result |
| --- | --- |
| `Async::HTTP::Internet.get(url)` (what we sent) | **403** Akamai error page |
| same, plus a `user-agent` header | **401 Invalid API key.** — reached the API |

The credentials were never the problem. `lib/goodreads.rb` now sends a User-Agent on every request.

This also fixed a latent load-order bug: `lib/goodreads.rb` called `Async::HTTP::Internet.get` but required only `async/http/internet`, not `.../internet/instance` which defines that singleton. It worked purely because `lib/alternate_isbns.rb` happened to load first.

## 2. OverDrive blocks datacenter IPs

The library lookup returns `403 Forbidden — Request forbidden by administrative rules.` from CI. Not fixable in code: the request already carries a browser User-Agent and referer, and the identical request from a residential IP returns six libraries for 94103. It is an IP ACL on `www.overdrive.com`.

The real bug this exposed is that a blocked lookup gave the user a bare 500. It now returns them to the zip code form with an actionable message — the same treatment `Bookmooch.available?` already gets. `test_0006` asserts that branch when OverDrive is unreachable and the full flow when it is not, mirroring the existing BookMooch-unavailable branch in `test_0009`. Nothing is skipped or mocked.

## Underlying defect in both

Neither `lib/goodreads.rb` nor `Overdrive.local_libraries` checked HTTP status, so a rejected request became an empty shelf list or an opaque `NoMethodError: undefined method 'attributes' for nil`. Both now raise quoting what actually came back — which is how both causes above were diagnosed rather than guessed at.

## Result

| | Runs | Assertions | Failures | Errors |
| --- | --- | --- | --- | --- |
| `main` | 129 | 273 | 1 | 2 |
| This PR | 140 | 309 | **0** | **0** |

Split out of #1317, which is now just the SQLite fix. **Merge this one first** — #1317 will show these same three pre-existing failures until it does.