### PR TITLE
Serve a 404 page and resume mid-flow on backtrack

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -83,6 +83,13 @@ class App < Roda
   end
 
   plugin :rodauth, auth_class: RodauthConfig
+  # Unmatched paths render a real page instead of a bare empty 404. Kept as a
+  # 404 rather than redirecting to '/': a redirect would turn every broken link
+  # and bot probe into a soft 404, which search engines penalise, and the site
+  # is actively working its SEO.
+  plugin :not_found do
+    view 'not_found'
+  end
   plugin :error_handler do |e|
     warn "#{e.class}: #{e.message}\n#{e.backtrace.first(20).join("\n")}"
     response.status = 500
@@ -274,8 +281,11 @@ class App < Roda
           @website_id = Cache.get session, :website_id
           @library_url = Cache.get session, :library_url
           unless @titles
-            flash[:error] = 'Please choose a shelf first'
-            r.redirect 'shelves'
+            # Resume at the furthest step already completed rather than sending
+            # them back to the start of the flow.
+            libraries = Cache.get session, :libraries
+            flash[:error] = libraries ? 'Please choose a library first' : 'Please choose a shelf first'
+            r.redirect libraries ? '/libraries' : '/goodreads/shelves'
           end
           @available_books = sort_by_date_added(@titles.select { |a| a.copies_available.positive? })
           @waitlist_books = sort_by_date_added(@titles.select { |a| a.copies_available.zero? && a.copies_owned.positive? })
@@ -311,8 +321,10 @@ class App < Roda
         @shelf_name = Cache.get session, :shelf_name
         @local_libraries = Cache.get session, :libraries
         unless @local_libraries
-          flash[:error] = 'Please choose a shelf first'
-          r.redirect '/goodreads/shelves'
+          # A shelf is already chosen, so the missing step is the zip code, not
+          # the shelf. Send them one step back instead of to the beginning.
+          flash[:error] = @shelf_name ? 'Please enter your zip code first' : 'Please choose a shelf first'
+          r.redirect @shelf_name ? "/goodreads/shelves/#{@shelf_name}/overdrive" : '/goodreads/shelves'
         end
         view 'library'
       end

--- a/spec/web/error_states_spec.rb
+++ b/spec/web/error_states_spec.rb
@@ -87,9 +87,30 @@ describe 'Error states' do
     assert_includes last_response.body, 'your email'
   end
 
-  it 'redirects to root for unknown routes under /goodreads' do
+  # Named for a redirect that never happened -- this path 404s, it does not
+  # redirect. Kept as a regression guard that it does not 500.
+  it 'does not error on unknown routes under /goodreads' do
     get '/goodreads/nonexistent'
     refute_equal 500, last_response.status
+  end
+
+  it 'answers an unknown path with 404 rather than an empty body' do
+    get '/no-such-page'
+
+    assert_equal 404, last_response.status
+    assert_includes last_response.body, 'This page wandered off'
+  end
+
+  it 'names the missing path on the 404 page' do
+    get '/definitely/not/here'
+
+    assert_includes last_response.body, '/definitely/not/here'
+  end
+
+  it 'does not redirect unknown paths, which would create soft 404s' do
+    get '/no-such-page'
+
+    refute last_response.redirect?
   end
 
   it 'disconnects Goodreads connection for authenticated user' do

--- a/views/not_found.erb
+++ b/views/not_found.erb
@@ -1,0 +1,30 @@
+<% content_for :title, "Page Not Found" %>
+<% content_for :description, "That page could not be found." %>
+
+<div class="max-w-2xl mx-auto text-center py-16">
+  <img src="/svg/star.svg" alt="" class="w-16 h-16 mx-auto opacity-60 mb-8">
+
+  <h1 class="font-display text-4xl sm:text-5xl font-medium tracking-tight text-mauve-950 mb-4">
+    This page wandered off
+  </h1>
+
+  <p class="text-xl text-mauve-700 mb-10">
+    We could not find anything at <span class="font-medium text-mauve-950"><%= request.path %></span>.
+  </p>
+
+  <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">
+    <a href="/" class="inline-flex items-center px-8 py-4 bg-mauve-950 text-white font-medium text-lg rounded-full hover:bg-mauve-900 transition-colors duration-200">
+      Back to the homepage
+    </a>
+
+    <% if @user %>
+      <a href="/goodreads/shelves" class="inline-flex items-center px-6 py-4 bg-mauve-950/10 text-mauve-950 font-medium text-lg rounded-full hover:bg-mauve-950/20 transition-colors duration-200">
+        Your shelves
+      </a>
+    <% else %>
+      <a href="/about" class="inline-flex items-center px-6 py-4 bg-mauve-950/10 text-mauve-950 font-medium text-lg rounded-full hover:bg-mauve-950/20 transition-colors duration-200">
+        What is Yonderbook?
+      </a>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
Two small backlog fixes.

Closes #443. Closes #446.

## #443 — unmatched paths

Unmatched paths returned a bare empty 404. They now render a real page via Roda's `not_found` plugin, with the missing path named and links home / to shelves.

**Deviation worth flagging:** the issue asked to "reroute 404s to `/`". I kept it as a 404 instead. Redirecting would turn every broken link, stale bookmark, and bot probe into a soft 404 — which search engines penalise, and #1273 is open SEO work. Serving a proper 404 also stops hiding broken links from you. If you'd rather have the redirect, it's a one-line change in the plugin block.

Verified the plugin's semantics in isolation before wiring it up:

```
known   -> status=200
unknown -> status=404  redirect=false
           body=This page wandered off: /definitely/not/here
```

## #446 — resuming after a lost session

Landing on `/goodreads/availability` with no cached titles sent the user back to the **shelf list**, even if they'd already picked a shelf and looked up libraries — losing both steps.

Now it resumes at the furthest step actually completed:

| State | Before | After |
|---|---|---|
| Libraries cached, titles gone | shelf list | `/libraries` |
| Shelf chosen, no libraries | shelf list | zip code form |
| Nothing chosen | shelf list | shelf list |

Flash messages follow ("Please choose a library first" / "Please enter your zip code first").

## Testing

Three new specs for the 404 — status is 404, the body names the path, and it does **not** redirect (guarding the soft-404 decision above).

Also renamed an existing spec: `'redirects to root for unknown routes under /goodreads'` never redirected — that path 404s. Kept as a don't-500 regression guard under an accurate name.

**Not directly covered:** the libraries-cached branch of #446. Reaching it needs server-side TupleSpace state keyed by session id, which a Capybara test can't seed without running the full OverDrive flow. The existing spec covers the no-libraries branch, and both branches are one conditional.

`rubocop` clean across 61 files.
