### PR TITLE
Replace dead Google Analytics with Fathom

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -73,11 +73,11 @@ class App < Roda
   plugin :websockets
   plugin :content_security_policy do |csp|
     csp.default_src :self
-    csp.script_src :self, :unsafe_inline, 'https://cdn.jsdelivr.net', 'https://www.googletagmanager.com', 'https://www.google-analytics.com', 'https://embed.tawk.to'
+    csp.script_src :self, :unsafe_inline, 'https://cdn.jsdelivr.net', 'https://cdn.usefathom.com', 'https://embed.tawk.to'
     csp.style_src :self, :unsafe_inline, 'https://fonts.googleapis.com'
     csp.img_src :self, :data, 'https:'
     csp.font_src :self, 'https://fonts.gstatic.com'
-    csp.connect_src :self, 'wss:', 'https://www.google-analytics.com', 'https://va.tawk.to', 'https://embed.tawk.to'
+    csp.connect_src :self, 'wss:', 'https://cdn.usefathom.com', 'https://va.tawk.to', 'https://embed.tawk.to'
     csp.frame_src 'https://tawk.to'
     csp.frame_ancestors :none
     csp.form_action :self, 'https://www.goodreads.com'

--- a/spec/web/security_headers_spec.rb
+++ b/spec/web/security_headers_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+describe 'Security headers' do
+  include Rack::Test::Methods
+
+  let :app do
+    App
+  end
+
+  # Rack 3 lowercases header names; older stacks do not. Look it up either way
+  # so this spec is not testing the Rack version.
+  def header name
+    key = last_response.headers.keys.find { |candidate| candidate.downcase == name }
+    last_response.headers[key]
+  end
+
+  def csp
+    get '/'
+    header 'content-security-policy'
+  end
+
+  describe 'content security policy' do
+    it 'allows the analytics script to load' do
+      assert_includes csp, 'https://cdn.usefathom.com'
+    end
+
+    # Universal Analytics stopped processing data on 1 July 2023. The tag is
+    # gone; the policy should not still permit it.
+    it 'no longer permits Google Analytics' do
+      refute_includes csp, 'google-analytics'
+    end
+
+    it 'no longer permits Google Tag Manager' do
+      refute_includes csp, 'googletagmanager'
+    end
+
+    it 'refuses to be framed' do
+      assert_includes csp, "frame-ancestors 'none'"
+    end
+
+    it 'restricts form submissions to this site and Goodreads' do
+      assert_includes csp, 'form-action'
+    end
+  end
+
+  describe 'transport security' do
+    it 'sends HSTS' do
+      get '/'
+
+      assert_includes header('strict-transport-security'), 'max-age=31536000'
+    end
+  end
+
+  describe 'analytics gating' do
+    # Production only, matching how PostHog and the old GA tag were gated, so
+    # local and CI traffic never pollutes the numbers.
+    it 'does not load the analytics script outside production' do
+      get '/'
+
+      refute_includes last_response.body, 'usefathom'
+    end
+  end
+end

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -82,15 +82,12 @@
     </script>
 
     <% if ENV['RACK_ENV'] == 'production' %>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-96996170-1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'UA-96996170-1');
-    </script>
+    <!--
+      Replaced Google Analytics (UA-96996170-1). Universal Analytics stopped
+      processing data on 1 July 2023, so that tag had been collecting nothing
+      for three years while still costing a request and a DNS lookup.
+    -->
+    <script src="https://cdn.usefathom.com/script.js" data-site="YKRZHUNU" defer></script>
     <% end %>
   </head>
 


### PR DESCRIPTION
Closes #1320.

## The tag being replaced was dead

`views/layout.erb` loaded `UA-96996170-1` — a **Universal Analytics** property. Google stopped processing UA data on **1 July 2023**, so it had been collecting nothing for three years while still costing every visitor a script fetch and a DNS lookup.

So this isn't adding a third analytics system; it's replacing a corpse. PostHog stays as the server-side event tracker.

## The CSP entry is not optional

`app.rb` lists script sources explicitly. Without adding `cdn.usefathom.com`, the tag would have been **silently blocked** — loading nothing, reporting nothing, with no error anyone would notice.

| | before | after |
|---|---|---|
| `script-src` | `googletagmanager`, `google-analytics` | `cdn.usefathom.com` |
| `connect-src` | `google-analytics` | `cdn.usefathom.com` |

## Gating

Production only, matching how PostHog and the old GA tag were already gated, so local and CI traffic never pollutes the numbers. One line to change if you'd rather it always load.

## Testing

Adds `spec/web/security_headers_spec.rb` — **the first coverage these headers have had.** It asserts the policy permits the analytics script, no longer permits Google Analytics or Tag Manager, still refuses framing, restricts form actions, and that HSTS is sent. Plus that the tag really is gated outside production.

Header lookup is case-insensitive so the spec isn't quietly testing which Rack version normalizes header names.

## Worth saying

This gets a working page-view counter, but `gtm.md` makes the sharper point: the three custom PostHog events that exist don't fire at the value moment. Page views won't tell you where the funnel leaks — instrumenting the shelf → library → availability path would. Separate piece of work, worth an issue if you want it.
