### PR TITLE
Stop import specs racing the request they assert on

### DIFF
--- a/spec/web/import_spec.rb
+++ b/spec/web/import_spec.rb
@@ -24,10 +24,15 @@ describe 'Goodreads CSV import' do
 
   # Clicks by id, not by label: the button reads "Import my library" the first
   # time and "Replace my library" once a library exists.
-  def import fixture_name
+  #
+  # click_button returns as soon as the click is dispatched, so the POST can
+  # still be in flight afterwards. Any assertion made straight against the
+  # database would race it, so wait for the resulting page first.
+  def import fixture_name, rejected: false
     visit '/import'
     attach_file 'library', fixture(fixture_name)
     click_button 'import-submit'
+    assert_current_path '/goodreads/shelves' unless rejected
   end
 
   it 'requires a login' do
@@ -85,14 +90,14 @@ describe 'Goodreads CSV import' do
 
   it 'rejects a CSV that is not a Goodreads export, with an actionable message' do
     logged_in_account
-    import 'not_goodreads.csv'
+    import 'not_goodreads.csv', rejected: true
 
     assert_text 'goodreads.com/review/import'
   end
 
   it 'keeps the user on the import page when the upload is rejected' do
     logged_in_account
-    import 'not_goodreads.csv'
+    import 'not_goodreads.csv', rejected: true
 
     assert_text 'How to get your export'
   end
@@ -118,6 +123,8 @@ describe 'Goodreads CSV import' do
     import 'goodreads_export.csv'
     visit '/import'
     accept_confirm { click_button 'Remove it' }
+    # Same race: wait for the redirect before reading the database.
+    assert_text 'has been removed'
 
     assert_equal 0, DB[:imported_books].where(user_id: account[:id]).count
   end


### PR DESCRIPTION
Fixes the failure on #1328's run:

```
Goodreads CSV import#test_0012_removes the imported library on request
Expected: 0
  Actual: 3
```

## Not a code bug

The removal works. The **test** read the database before the request that empties it had finished.

`click_button` returns as soon as the click is dispatched — the POST is often still in flight. Five specs asserted straight against `DB[:imported_books]` with nothing forcing the browser to settle first:

| Line | Spec |
|---|---|
| 64 | persists the library to the database rather than the session |
| 70 | treats an unrated book as rating 0 rather than dropping it |
| 78 | normalizes Date Added to a sortable ISO date |
| 110 | replaces the previous import rather than merging into it |
| 129 | removes the imported library on request |

They passed on #1324's branch by timing luck and failed once a slower runner shifted it. All five were latent; only one happened to trip.

## Fix

The `import` helper now waits for the redirect before returning, so no caller can race it. The removal spec waits for its flash, since that redirect lands back on the same path and offers nothing else to synchronize on. Rejection cases opt out with `rejected: true` — a rejected upload stays put and those specs already wait on flash text.

## Note on the other flake

This is a *different* problem from #1329. That one is `Net::ReadTimeout` in the Goodreads OAuth spec driving Amazon's live sign-in, and it is not fixed here — this is my own test race, entirely within our control.

## Merge order

`main` carries these racy specs now, so they will trip intermittently until this lands. Worth merging ahead of #1328, which will then go green on a re-run.
