### PR TITLE
Retry browser specs on driver timeouts only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,5 +56,6 @@ group :test do
   gem 'falcon-capybara'
   gem 'minitest'
   gem 'minitest-capybara'
+  gem 'minitest-retry'
   gem 'rack-test'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,8 @@ GEM
       capybara
       minitest (~> 5.0)
       rake
+    minitest-retry (0.3.1)
+      minitest (>= 5.0)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     net-http (0.9.1)
@@ -338,6 +340,7 @@ DEPENDENCIES
   mail
   minitest
   minitest-capybara
+  minitest-retry
   nokogiri
   oauth
   oauth2

--- a/spec/web/retry_policy_spec.rb
+++ b/spec/web/retry_policy_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+# Guards the retry policy configured in spec_helper.rb.
+#
+# A retry that is too broad silently converts real, reproducible failures into
+# passes on the second attempt. These assertions exist so that widening the list
+# has to be a deliberate act rather than a convenient one.
+describe 'flaky test retry policy' do
+  let(:retried) { Minitest::Retry.exceptions_to_retry }
+
+  it 'retries the driver read timeout that blocks deploys' do
+    assert_includes retried, Net::ReadTimeout
+  end
+
+  it 'retries driver connection timeouts' do
+    assert_includes retried, Selenium::WebDriver::Error::TimeoutError
+  end
+
+  it 'never retries assertion failures, which would mask real bugs' do
+    refute_includes retried, Minitest::Assertion
+  end
+
+  # This is how the import button-label bug surfaced. Retrying it would have
+  # hidden a genuine defect.
+  it 'never retries element-not-found' do
+    refute_includes retried, Capybara::ElementNotFound
+  end
+
+  it 'retries a small, fixed number of times' do
+    assert_equal 2, Minitest::Retry.retry_count
+  end
+
+  it 'restricts retries to an explicit list rather than everything' do
+    refute_empty retried
+  end
+end

--- a/spec/web/spec_helper.rb
+++ b/spec/web/spec_helper.rb
@@ -8,8 +8,26 @@ require 'logger'
 require 'minitest/autorun'
 require 'minitest/capybara'
 require 'minitest/pride'
+require 'minitest/retry'
 require 'rack/test'
 require 'selenium-webdriver'
+
+# Retry ONLY driver and network timeouts, and only twice. See issue #1329.
+#
+# spec/web/system_spec.rb drives a real browser through goodreads.com and
+# Amazon's sign-in portal, with fixed sleeps and a loop to get past Amazon's
+# CVF challenge. When the runner is slow or Amazon presents a challenge,
+# Selenium's HTTP connection times out and the run fails for reasons that have
+# nothing to do with this codebase -- roughly a third of main's runs. Since
+# autoDeployTrigger is checksPass, that blocks production deploys until someone
+# re-runs the job by hand.
+#
+# The list is deliberately narrow. Minitest::Assertion is absent, so a genuine
+# bug still fails on the first attempt, and Capybara::ElementNotFound is absent
+# because that is usually a real defect -- it is how the button-label bug in
+# the import specs was caught. Retrying either would hide work, not save it.
+RETRIED_ERRORS = [Net::ReadTimeout, Net::OpenTimeout, Selenium::WebDriver::Error::TimeoutError].freeze
+Minitest::Retry.use! retry_count: 2, verbose: true, exceptions_to_retry: RETRIED_ERRORS
 
 # Load database connection first
 require_relative '../../lib/database'


### PR DESCRIPTION
Fixes #1329. Implements option 1 from that issue — the smallest change that keeps every test and stops the flake blocking deploys.

## Problem

`App#test_0004_connects Goodreads via OAuth and browses shelves` drives a real browser through `goodreads.com` and Amazon's sign-in portal, with fixed sleeps and a 3-attempt loop for Amazon's CVF challenge. When the runner is slow or Amazon presents a challenge, Selenium's HTTP connection times out.

Roughly a third of `main` runs fail this way — **including the merge of #1325, which changed one line of YAML.** With `autoDeployTrigger: checksPass`, that blocks production deploys until someone notices and re-runs the job. It already happened once with #1324.

## Fix

Retries at most twice, and only on:

- `Net::ReadTimeout` — the observed failure
- `Net::OpenTimeout`
- `Selenium::WebDriver::Error::TimeoutError`

**The narrowness is the point.** Two exclusions are deliberate:

| Excluded | Why |
|---|---|
| `Minitest::Assertion` | A real bug must fail on the first attempt |
| `Capybara::ElementNotFound` | Usually a genuine defect — it's how the import button-label bug was caught in #1324 |

Verified against the installed gem that `exceptions_to_retry` restricts retries to the listed classes rather than adding to a default:

```
Net::ReadTimeout             retried=true
Selenium TimeoutError        retried=true
Minitest::Assertion          retried=false
Capybara::ElementNotFound    retried=false
retry_count = 2
```

## Testing

`spec/web/retry_policy_spec.rb` asserts those exclusions directly. A retry list that quietly grows turns reproducible failures into second-attempt passes, so widening it should require editing a spec that says why not to.

## What this does not fix

The underlying test is still slow, still depends on Amazon being cooperative, and per CLAUDE.md the flow needs two manual clicks anyway — it was never fully automatable against the live provider. Options 2 and 3 in #1329 (replacing the fixed sleeps, or moving it out of the default suite) remain open if the flake persists. This just stops it gating deploys.
