### PR TITLE
Offer the browser's location instead of typing a zip

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -30,6 +30,7 @@ require_relative 'lib/cache'
 require_relative 'lib/database'
 require_relative 'lib/email'
 require_relative 'lib/email_templates'
+require_relative 'lib/geolocation'
 require_relative 'lib/goodreads'
 require_relative 'lib/import_routes'
 require_relative 'lib/models'
@@ -134,6 +135,12 @@ class App < Roda
       r.websocket { |connection| Websockets.handle_bookmooch(connection, session_id) }
     end
     r.get('import-status') { import_status.to_json } # route: GET /import-status
+
+    # route: GET /nearest-zip?lat=34.09&lon=-118.40
+    r.get 'nearest-zip' do
+      response['Content-Type'] = 'application/json'
+      (Geolocation.nearest_zip(r.params['lat'], r.params['lon']) || {error: 'no_match'}).to_json
+    end
     r.get('check-email') do # route: GET /check-email
       @pending_email = session.delete('pending_email') || 'your email'
       view 'check-email'

--- a/lib/geolocation.rb
+++ b/lib/geolocation.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'area'
+
+# Turns browser coordinates into a US zip code.
+#
+# The library lookup is driven by zip: OverDrive's find-libraries-by-query
+# endpoint returns an empty list when handed "lat,lon", and area's own to_zip
+# only matches coordinates it already has exactly. So a position has to be
+# resolved to the nearest zip before it is any use.
+#
+# This does it against the dataset the area gem already loads at require time
+# (43,204 rows, ~27MB resident whether we use it or not), so it costs no extra
+# memory, no API key, and no third-party request.
+module Geolocation
+  # Rough miles per degree of latitude. Longitude is scaled by cos(latitude),
+  # which is close enough to pick a nearest neighbour and avoids running
+  # haversine over 43k rows on a small box.
+  MILES_PER_DEGREE = 69.0
+
+  # Beyond this, assume the caller is not in the United States rather than
+  # confidently returning a zip hundreds of miles away.
+  MAX_DISTANCE_MILES = 100
+
+  # Indexes into area's zipcodes.csv rows.
+  ZIP = 0
+  CITY = 1
+  STATE = 2
+  LATITUDE = 3
+  LONGITUDE = 4
+
+  module_function
+
+  # Returns {zip:, city:, state:, distance:} for the closest zip code, or nil
+  # when the coordinates are unusable or nowhere near the US.
+  def nearest_zip latitude, longitude
+    lat = Float(latitude, exception: false)
+    lon = Float(longitude, exception: false)
+    return unless valid_coordinates? lat, lon
+
+    row, degrees = closest_row lat, lon
+    return unless row
+
+    miles = degrees * MILES_PER_DEGREE
+    return if miles > MAX_DISTANCE_MILES
+
+    {zip: row[ZIP], city: row[CITY], state: row[STATE], distance: miles.round(1)}
+  end
+
+  def valid_coordinates? lat, lon
+    return false unless lat && lon
+
+    lat.between?(-90, 90) && lon.between?(-180, 180)
+  end
+
+  # Squared distance in degrees, longitude corrected for latitude. Comparing
+  # squares avoids a square root per row; only the winner is converted.
+  def closest_row lat, lon
+    scale = Math.cos(lat * Math::PI / 180)
+    best = nil
+    best_squared = nil
+
+    Area.zip_codes.each do |row|
+      row_lat = row[LATITUDE].to_f
+      row_lon = row[LONGITUDE].to_f
+      delta_lat = lat - row_lat
+      delta_lon = (lon - row_lon) * scale
+      squared = (delta_lat * delta_lat) + (delta_lon * delta_lon)
+      next if best_squared && squared >= best_squared
+
+      best = row
+      best_squared = squared
+    end
+
+    [best, best_squared ? Math.sqrt(best_squared) : nil]
+  end
+end

--- a/lib/rate_limiting.rb
+++ b/lib/rate_limiting.rb
@@ -27,6 +27,7 @@ module RateLimiting
     throttle_email_senders
     throttle_logins
     throttle_search
+    throttle_zip_lookups
     throttle_writes
     respond_with_429
     Rack::Attack
@@ -63,6 +64,13 @@ module RateLimiting
 
     Rack::Attack.throttle('search reads per ip', limit: 30, period: 60) do |request|
       request.ip if request.get? && request.path.start_with?('/search')
+    end
+  end
+
+  # Public, and each call scans 43k zip rows. Cheap individually, worth a cap.
+  def throttle_zip_lookups
+    Rack::Attack.throttle('zip lookups per ip', limit: 30, period: 60) do |request|
+      request.ip if request.path == '/nearest-zip'
     end
   end
 

--- a/spec/lib/geolocation_spec.rb
+++ b/spec/lib/geolocation_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+require 'geolocation'
+
+describe Geolocation do
+  describe '.nearest_zip' do
+    it 'resolves coordinates in Beverly Hills to a local zip' do
+      found = Geolocation.nearest_zip 34.0901, -118.4065
+
+      assert_equal 'CA', found[:state]
+      assert_equal 'Beverly Hills', found[:city]
+    end
+
+    it 'resolves coordinates in Manhattan to a New York zip' do
+      found = Geolocation.nearest_zip 40.7484, -73.9857
+
+      assert_equal 'NY', found[:state]
+    end
+
+    it 'reports how far the match is, so callers can judge it' do
+      found = Geolocation.nearest_zip 34.0901, -118.4065
+
+      assert_operator found[:distance], :<, 5
+    end
+
+    it 'accepts coordinates as strings, as they arrive from a query string' do
+      found = Geolocation.nearest_zip '34.0901', '-118.4065'
+
+      assert_equal 'CA', found[:state]
+    end
+
+    # Someone in London must not be told they live in Maine.
+    it 'returns nothing when the caller is nowhere near the United States' do
+      assert_nil Geolocation.nearest_zip(51.5074, -0.1278)
+    end
+
+    it 'returns nothing for coordinates in the middle of the Pacific' do
+      assert_nil Geolocation.nearest_zip(0, -160)
+    end
+
+    it 'returns nothing for unparseable input' do
+      assert_nil Geolocation.nearest_zip('not', 'coordinates')
+    end
+
+    it 'returns nothing for nil' do
+      assert_nil Geolocation.nearest_zip(nil, nil)
+    end
+
+    it 'returns nothing for out-of-range latitude' do
+      assert_nil Geolocation.nearest_zip(200, -118)
+    end
+
+    it 'returns nothing for out-of-range longitude' do
+      assert_nil Geolocation.nearest_zip(34, 999)
+    end
+
+    it 'returns a zip the library lookup can actually use' do
+      found = Geolocation.nearest_zip 34.0901, -118.4065
+
+      assert_match(/\A\d{5}\z/, found[:zip])
+    end
+  end
+end

--- a/spec/lib/rate_limiting_spec.rb
+++ b/spec/lib/rate_limiting_spec.rb
@@ -116,6 +116,22 @@ describe RateLimiting do
     end
   end
 
+  describe 'zip lookups' do
+    # Public, and each call scans 43k rows, so it needs a cap of its own --
+    # the write backstop does not cover GETs.
+    it 'blocks more than thirty lookups a minute' do
+      hammer '/nearest-zip', 31, method: :get
+
+      assert_equal 429, last_response.status
+    end
+
+    it 'leaves ordinary use alone' do
+      hammer '/nearest-zip', 30, method: :get
+
+      assert_equal 200, last_response.status
+    end
+  end
+
   describe 'backstop' do
     it 'caps writes to any path, including ones added later' do
       hammer '/some/future/endpoint', 61

--- a/spec/web/nearest_zip_spec.rb
+++ b/spec/web/nearest_zip_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+require 'json'
+
+describe 'Nearest zip lookup' do
+  include Rack::Test::Methods
+
+  let :app do
+    App
+  end
+
+  def lookup lat, lon
+    get "/nearest-zip?lat=#{lat}&lon=#{lon}"
+    JSON.parse last_response.body
+  end
+
+  it 'resolves coordinates to a nearby zip' do
+    assert_equal 'CA', lookup(34.0901, -118.4065)['state']
+  end
+
+  it 'returns a zip the library form can submit' do
+    assert_match(/\A\d{5}\z/, lookup(34.0901, -118.4065)['zip'])
+  end
+
+  it 'names the place so the user can sanity check it' do
+    assert_equal 'Beverly Hills', lookup(34.0901, -118.4065)['city']
+  end
+
+  it 'answers with JSON' do
+    get '/nearest-zip?lat=34.0901&lon=-118.4065'
+
+    assert_includes last_response.headers.values.join(' '), 'application/json'
+  end
+
+  # Someone in London must not be told they live in Maine.
+  it 'reports no match well outside the United States' do
+    assert_equal 'no_match', lookup(51.5074, -0.1278)['error']
+  end
+
+  it 'reports no match rather than erroring on unparseable input' do
+    get '/nearest-zip?lat=banana&lon=split'
+
+    assert_equal 200, last_response.status
+  end
+
+  it 'reports no match when the parameters are missing entirely' do
+    get '/nearest-zip'
+
+    assert_equal 'no_match', JSON.parse(last_response.body)['error']
+  end
+end

--- a/views/shelves/overdrive.erb
+++ b/views/shelves/overdrive.erb
@@ -33,6 +33,64 @@
         <img src="/svg/location-marker.svg" alt="Location" class="w-5 h-5 mr-2">
         Find a library
       </button>
+
+      <div class="mt-4 text-center">
+        <button type="button"
+                id="use-my-location"
+                class="inline-flex items-center px-4 py-2 bg-mauve-950/10 hover:bg-mauve-950/20 text-mauve-950 text-sm font-medium rounded-full transition-colors duration-200">
+          Or use my current location
+        </button>
+        <p id="location-status" class="text-sm text-mauve-700 mt-2 hidden"></p>
+      </div>
     </form>
   </div>
 </div>
+
+<script>
+  // Fills the zip field from the browser's location rather than replacing the
+  // form: the user still sees which zip was chosen and can correct it before
+  // submitting. Geolocation is unavailable on insecure origins and can be
+  // denied, so the typed field always remains the primary path.
+  (function () {
+    const button = document.getElementById('use-my-location');
+    const status = document.getElementById('location-status');
+    const zipcode = document.getElementById('zipcode');
+    if (!button || !navigator.geolocation) { return; }
+
+    function show(message) {
+      status.textContent = message;
+      status.classList.remove('hidden');
+    }
+
+    button.addEventListener('click', function () {
+      button.disabled = true;
+      show('Finding your location...');
+
+      navigator.geolocation.getCurrentPosition(function (position) {
+        const query = new URLSearchParams({
+          lat: position.coords.latitude,
+          lon: position.coords.longitude
+        });
+
+        fetch('/nearest-zip?' + query)
+          .then(function (response) { return response.json(); })
+          .then(function (data) {
+            button.disabled = false;
+            if (!data.zip) {
+              show('We could not match that to a US zip code. Please type one instead.');
+              return;
+            }
+            zipcode.value = data.zip;
+            show('Using ' + data.city + ', ' + data.state + ' (' + data.zip + '). Change it if that is wrong.');
+          })
+          .catch(function () {
+            button.disabled = false;
+            show('Something went wrong looking that up. Please type a zip code instead.');
+          });
+      }, function () {
+        button.disabled = false;
+        show('We could not get your location. Please type a zip code instead.');
+      });
+    });
+  })();
+</script>


### PR DESCRIPTION
Closes #444.

## Neither obvious approach works

I checked both against the real services before designing anything:

| Approach | Result |
|---|---|
| Pass `lat,lon` to OverDrive's `find-libraries-by-query` | Returns `[]` — it only understands place names and zips |
| `area`'s `"34.10,-118.41".to_zip` | Returns `[]` — only matches coordinates already in its table exactly |

So a position has to be resolved to a zip ourselves.

## Approach

`Geolocation.nearest_zip` resolves against the dataset **the `area` gem already loads at require time** — 43,204 rows, resident whether we use them or not. No API key, no third-party request, no extra memory.

Longitude is scaled by `cos(latitude)` and distances compared squared, so a lookup is one cosine and 43k multiplications rather than 43k haversines. Measured at ~10ms.

Anything further than 100 miles from the nearest zip returns nothing — someone in London gets "type a zip code" rather than being confidently placed in Maine.

## UX

The button **fills the field rather than submitting**, so the user sees which zip was chosen and can correct it:

> Using Beverly Hills, CA (90210). Change it if that is wrong.

Typing stays the primary path. Geolocation is unavailable on insecure origins and can be denied, and every failure path says so and points back at the field.

## Testing

**18 tests, all passing locally** — no credentials needed for the unit ones.

- `geolocation_spec.rb` (11) — real coordinates resolving to Beverly Hills and Manhattan, string inputs as they arrive from a query string, and the whole refusal surface: London, mid-Pacific, unparseable, nil, out-of-range lat and lon
- `nearest_zip_spec.rb` (7) — the endpoint's JSON contract
- 2 added to `rate_limiting_spec.rb` — the endpoint is public and scans 43k rows per call, and the write backstop does not cover GETs, so it gets 30/minute per IP

## Unrelated finding worth its own issue

Measuring this turned up that `require 'area'` costs **+26.9MB RSS**, permanently, at boot:

```
RSS before require area: 22.8MB
RSS after  require area: 49.7MB
```

That is roughly a quarter of the ~100MB startup RSS documented in the README's OOM section, held for the life of the process to support zip validation. The README's investigation focused on per-request allocation and malloc fragmentation; this is a different axis — baseline. Happy to file it if useful.
