### PR TITLE
Load the zip dataset only when it is needed

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,7 +2,6 @@
 
 system 'roda-parse_routes', '-f', 'routes.json', __FILE__ if ENV.fetch('RACK_ENV', 'development') == 'development'
 
-require 'area'
 require 'async'
 require 'rack/host_redirect'
 require 'roda'
@@ -318,7 +317,7 @@ class App < Roda
           flash[:error] = 'You need to enter a zip code'
           r.redirect '/libraries'
         end
-        unless zip.to_latlon
+        unless Geolocation.known_zip?(zip)
           flash[:error] = 'please try a different zip code'
           r.redirect '/libraries'
         end

--- a/lib/geolocation.rb
+++ b/lib/geolocation.rb
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 
-require 'area'
-
-# Turns browser coordinates into a US zip code.
+# Turns browser coordinates into a US zip code, and checks that a typed zip is
+# real. The single place in this app that touches the `area` gem.
 #
 # The library lookup is driven by zip: OverDrive's find-libraries-by-query
 # endpoint returns an empty list when handed "lat,lon", and area's own to_zip
 # only matches coordinates it already has exactly. So a position has to be
 # resolved to the nearest zip before it is any use.
 #
-# This does it against the dataset the area gem already loads at require time
-# (43,204 rows, ~27MB resident whether we use it or not), so it costs no extra
-# memory, no API key, and no third-party request.
+# `area` is required lazily, not at boot. Loading it reads 43,204 rows into
+# ~302k String objects and costs +26.9MB of resident memory, about a quarter of
+# this app's startup RSS on a 512MB instance that OOM-kills daily. The bot
+# traffic that drives that pressure only ever hits '/', and most sessions never
+# reach the library step, so a process that never needs zip data no longer pays
+# for it. See #1334 -- replacing the dataset outright is the fuller fix, and
+# keeping every use behind this module is what makes that a small change.
 module Geolocation
   # Rough miles per degree of latitude. Longitude is scaled by cos(latitude),
   # which is close enough to pick a nearest neighbour and avoids running
@@ -30,6 +33,20 @@ module Geolocation
   LONGITUDE = 4
 
   module_function
+
+  # True when the string is a zip code that actually exists. Replaces a bare
+  # `zip.to_latlon` truthiness check; the coordinates were always discarded.
+  def known_zip? zip
+    return false unless zip.to_s.match?(/\A\d{5}\z/)
+
+    !zip_codes.assoc(zip).nil?
+  end
+
+  # Deferred on purpose -- see the note above the module.
+  def zip_codes
+    require 'area'
+    Area.zip_codes
+  end
 
   # Returns {zip:, city:, state:, distance:} for the closest zip code, or nil
   # when the coordinates are unusable or nowhere near the US.
@@ -60,7 +77,7 @@ module Geolocation
     best = nil
     best_squared = nil
 
-    Area.zip_codes.each do |row|
+    zip_codes.each do |row|
       row_lat = row[LATITUDE].to_f
       row_lon = row[LONGITUDE].to_f
       delta_lat = lat - row_lat

--- a/spec/lib/geolocation_spec.rb
+++ b/spec/lib/geolocation_spec.rb
@@ -4,6 +4,28 @@ require_relative 'spec_helper'
 require 'geolocation'
 
 describe Geolocation do
+  describe '.known_zip?' do
+    it 'accepts a real zip code' do
+      assert Geolocation.known_zip?('90210')
+    end
+
+    it 'rejects a five-digit number that is not a zip code' do
+      refute Geolocation.known_zip?('00001')
+    end
+
+    it 'rejects anything that is not five digits' do
+      refute Geolocation.known_zip?('9021')
+    end
+
+    it 'rejects letters without consulting the dataset' do
+      refute Geolocation.known_zip?('ABCDE')
+    end
+
+    it 'rejects nil' do
+      refute Geolocation.known_zip?(nil)
+    end
+  end
+
   describe '.nearest_zip' do
     it 'resolves coordinates in Beverly Hills to a local zip' do
       found = Geolocation.nearest_zip 34.0901, -118.4065


### PR DESCRIPTION
Part of #1334 — option 1 from that issue, plus the refactor that makes option 2 small.

## Result

```
boot cost before: +26.9MB
boot cost after:  +0.1MB
```

Verified that `area` is genuinely absent from `$LOADED_FEATURES` after boot and only appears after the first zip lookup:

```
after require geolocation: +0.1MB   (area loaded: false)
after first zip lookup:    +27.0MB  (area loaded: true)
```

## Why this is worth doing

`require 'area'` sat at the top of `app.rb` and read 43,204 rows into ~302k String objects at boot — roughly **a quarter of the ~100MB startup RSS** the README documents, on a 512MB instance that OOM-kills daily.

It bought exactly one thing, at `app.rb:321`: a `zip.to_latlon` truthiness check **whose coordinates were discarded**.

The traffic the README identifies as the main pressure is bots hitting `/` every minute. Those requests never touch zip data, and most real sessions never reach the library step either — so a process that never needs the dataset no longer pays for it.

## What this does not do

A process that *does* serve one library lookup pays the 27MB permanently, from that point on. This defers; it does not remove. #1334 covers replacing the dataset outright, where the measured floor is ~1.1MB of actual data.

Routing every `area` use through `Geolocation` is the part that makes that follow-up small — it is now one module rather than scattered call sites.

## Behaviour change

`Geolocation.known_zip?` replaces the `to_latlon` check. It rejects anything that is not five digits **before** consulting the dataset, so malformed input never triggers the 27MB load at all — which also means a bot posting junk zips cannot use that endpoint to inflate memory.

Five new specs cover it: a real zip, a five-digit non-zip, wrong length, letters, and nil. 16 tests in `geolocation_spec.rb`, all passing locally.
