### PR TITLE
Stop the library form loading the whole shelf

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -230,9 +230,6 @@ class App < Roda
             view 'shelves/show'
           end
 
-          # Blocking fetch for sub-routes that need @book_info
-          @book_info ||= fetch_shelf_blocking(@shelf_name)
-
           r.on 'bookmooch' do
             unless Bookmooch.available?
               flash[:error] = 'BookMooch appears to be down right now. Please try again later.'
@@ -241,12 +238,14 @@ class App < Roda
 
             # route: GET /goodreads/shelves/:id/bookmooch
             r.get true do
+              @book_info ||= fetch_shelf_blocking(@shelf_name)
               @new_count, @skip_count, @no_isbn_count = bookmooch_preview(@user.id, @book_info)
               view 'shelves/bookmooch'
             end
 
             # route: POST /goodreads/shelves/:id/bookmooch?username=foo&password=baz
             r.post do
+              @book_info ||= fetch_shelf_blocking(@shelf_name)
               BookmoochImport.clear_imports(@user.id) if r.params['reimport'] == '1'
               filtered = filter_already_imported_books(@user.id, @book_info)
               cache_bookmooch_params(r, filtered, @user.id, @book_info.size - filtered.size)
@@ -267,8 +266,13 @@ class App < Roda
           end
 
           r.is 'overdrive' do
+            # Renders a zip code form and nothing else. Deliberately does NOT
+            # load the shelf: doing so timed out on large shelves (#1333), and
+            # the "Get Books" link on the shelf index comes straight here, so
+            # nothing has warmed the cache yet.
             r.get(true) { view 'shelves/overdrive' } # route: GET /goodreads/shelves/:id/overdrive
             r.post do # route: POST /goodreads/shelves/:id/overdrive?consortium=1047
+              @book_info ||= fetch_shelf_blocking(@shelf_name)
               consortium = typecast_params.pos_int('consortium')
               unless consortium
                 flash[:error] = 'Invalid library selection'

--- a/spec/web/error_states_spec.rb
+++ b/spec/web/error_states_spec.rb
@@ -138,6 +138,24 @@ describe 'Error states' do
     assert last_response.redirect?
   end
 
+  # #1333: this page is a zip code form and nothing more, but it used to load
+  # the entire shelf from Goodreads first and time out on large ones. The
+  # "Get Books" link on the shelf index comes straight here, so the cache is
+  # cold on the common path.
+  it 'renders the library form without any shelf data cached' do
+    seed_goodreads_user
+    visit '/goodreads/shelves/to-read/overdrive'
+
+    assert_field 'zipcode'
+  end
+
+  it 'offers the location shortcut on the library form' do
+    seed_goodreads_user
+    visit '/goodreads/shelves/to-read/overdrive'
+
+    assert_button 'Or use my current location'
+  end
+
   it 'redirects from /goodreads/availability when no titles cached' do
     seed_goodreads_user
     visit '/goodreads/availability'


### PR DESCRIPTION
Fixes #1333 — `RequestTimeout::Error: GET /goodreads/shelves/to-read/overdrive exceeded 25s`.

## Cause

That page renders a zip code form and nothing else. But this sat above every sub-route under `:id`:

```ruby
# Blocking fetch for sub-routes that need @book_info
@book_info ||= fetch_shelf_blocking(@shelf_name)
```

So displaying a text input first ran a blocking, paginated Goodreads fetch of the entire shelf. On a large `to-read` shelf that exceeds the 25s timeout.

**It is the common path, not an edge case.** `views/shelves/index.erb` links "Get Books" straight to `shelves/<name>/overdrive`, bypassing the shelf page that would have warmed the cache. Anyone going library-hunting from the shelf list hits a cold cache every time.

## Fix

The fetch moves into the three routes that actually read `@book_info`:

| Route | Before | After |
|---|---|---|
| `GET .../overdrive` (zip form) | full shelf fetch | **none** |
| `GET .../bookmooch/progress` | full shelf fetch | **none** |
| `GET .../bookmooch/results` | full shelf fetch | **none** |
| `GET .../bookmooch` (preview) | fetch | fetch |
| `POST .../bookmooch` | fetch | fetch |
| `POST .../overdrive` | fetch | fetch |

The bookmooch progress and results pages were paying for data they never read either — progress renders a websocket page, results reads from the job cache.

## Honest limitation on testing

The two new specs assert the form renders with a cold cache. **They do not prove the fetch is gone** — the old code would also render, just slowly. Proving it without mocking would mean asserting on elapsed time, and I just removed a timing-based flake; adding one back to guard a fix would be a poor trade.

What they do guard is that the route works with no shelf data cached, which is the state that broke.

## Not addressed

`POST .../overdrive` still does a blocking fetch and could still be slow on a huge shelf — but there it is doing work the user explicitly asked for, rather than to draw a form. Prewarming the shelf asynchronously while the user types their zip would fix that too, but `load_or_start_shelf_import` sets a pending-import redirect target that would send them to the wrong page afterwards. Worth a separate issue if the POST turns out to time out in practice.
