### PR TITLE
Add an endpoint for OverDrive search URLs

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -32,6 +32,7 @@ require_relative 'lib/email_templates'
 require_relative 'lib/geolocation'
 require_relative 'lib/goodreads'
 require_relative 'lib/import_routes'
+require_relative 'lib/libby_url'
 require_relative 'lib/models'
 require_relative 'lib/oauth_helpers'
 require_relative 'lib/overdrive'
@@ -140,6 +141,13 @@ class App < Roda
       response['Content-Type'] = 'application/json'
       (Geolocation.nearest_zip(r.params['lat'], r.params['lon']) || {error: 'no_match'}).to_json
     end
+    # route: GET /api/libby_url?title=Piranesi&author=Susanna+Clarke
+    r.get 'api', 'libby_url' do
+      response['Content-Type'] = 'application/json'
+      url = LibbyUrl.for(r.params['title'], r.params['author'])
+      (url ? {url: url} : {error: 'title is required'}).to_json
+    end
+
     r.get('check-email') do # route: GET /check-email
       @pending_email = session.delete('pending_email') || 'your email'
       view 'check-email'

--- a/lib/libby_url.rb
+++ b/lib/libby_url.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+# Builds a URL that shows a book in OverDrive's public catalogue.
+#
+# Deliberately not a Libby deep link and deliberately not the authenticated
+# API. Libby is a single page app: https://libbyapp.com/search/query-Piranesi
+# answers 200 with an empty shell titled "Libby" and renders nothing useful to
+# someone following a link. A real deep link needs a library-specific path,
+# which the caller does not have -- the Signal bot has a title, sometimes an
+# author, and no ISBN or consortium.
+#
+# https://www.overdrive.com/search?q=... is server rendered and works with no
+# key, no token and no library chosen. Verified against the live site:
+#
+#   q=Piranesi                            -> "87 results for Piranesi"
+#   q=Piranesi Susanna Clarke             -> "34 results for ..."
+#   q=Parable of the Sower Octavia Butler -> "25 results for ..."
+#
+# Including the author narrows sensibly, so it is used when present.
+module LibbyUrl
+  SEARCH = 'https://www.overdrive.com/search'
+
+  module_function
+
+  # Returns a search URL, or nil when there is no title to search for.
+  def for title, author = nil
+    terms = [title, author].map { |term| term.to_s.strip }.reject(&:empty?)
+    return if terms.empty?
+
+    "#{SEARCH}?#{URI.encode_www_form(q: terms.join(' '))}"
+  end
+end

--- a/spec/lib/libby_url_spec.rb
+++ b/spec/lib/libby_url_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+require 'libby_url'
+
+describe LibbyUrl do
+  describe '.for' do
+    it 'builds a search URL from a title' do
+      assert_equal 'https://www.overdrive.com/search?q=Piranesi', LibbyUrl.for('Piranesi')
+    end
+
+    it 'includes the author when there is one, which narrows the results' do
+      assert_equal 'https://www.overdrive.com/search?q=Piranesi+Susanna+Clarke', LibbyUrl.for('Piranesi', 'Susanna Clarke')
+    end
+
+    it 'encodes characters that would break the query string' do
+      assert_includes LibbyUrl.for('Cats & Dogs'), 'q=Cats+%26+Dogs'
+    end
+
+    # The Signal bot's schedule stores author as nullable.
+    it 'works with no author' do
+      refute_nil LibbyUrl.for('Piranesi', nil)
+    end
+
+    it 'ignores a blank author rather than trailing a space' do
+      assert_equal LibbyUrl.for('Piranesi'), LibbyUrl.for('Piranesi', '   ')
+    end
+
+    it 'returns nothing without a title' do
+      assert_nil LibbyUrl.for(nil)
+    end
+
+    it 'returns nothing for a blank title' do
+      assert_nil LibbyUrl.for('   ')
+    end
+  end
+end

--- a/spec/web/libby_url_endpoint_spec.rb
+++ b/spec/web/libby_url_endpoint_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+require 'json'
+
+describe 'Libby URL endpoint' do
+  include Rack::Test::Methods
+
+  let :app do
+    App
+  end
+
+  def body_for query
+    get "/api/libby_url?#{query}"
+    JSON.parse last_response.body
+  end
+
+  it 'returns a search URL for a title' do
+    assert_equal 'https://www.overdrive.com/search?q=Piranesi', body_for('title=Piranesi')['url']
+  end
+
+  it 'includes the author when given one' do
+    assert_includes body_for('title=Piranesi&author=Susanna+Clarke')['url'], 'Susanna+Clarke'
+  end
+
+  it 'works without an author, which the caller may not have' do
+    refute_nil body_for('title=Piranesi')['url']
+  end
+
+  it 'explains itself when the title is missing' do
+    assert_equal 'title is required', body_for('')['error']
+  end
+
+  it 'answers with JSON' do
+    get '/api/libby_url?title=Piranesi'
+
+    assert_includes last_response.headers.values.join(' '), 'application/json'
+  end
+
+  it 'does not require authentication, since a bot calls it' do
+    get '/api/libby_url?title=Piranesi'
+
+    assert_equal 200, last_response.status
+  end
+end


### PR DESCRIPTION
Closes #1217.

## The issue's assumption did not hold

It supposed `lib/overdrive.rb` could supply a link. It cannot — `title.url` comes from `edition.dig('contentDetails', 0, 'href')`, produced by a product search scoped to a **collection token**, which only exists once a library has been chosen. There is no library-agnostic path through the authenticated API, and the Signal bot has no consortium.

Libby is no good either. Verified:

| URL | Result |
|---|---|
| `libbyapp.com/search/query-Piranesi` | 200, 33KB, `<title>Libby</title>` — the empty SPA shell the issue described |
| `overdrive.com/search?q=Piranesi` | 200, 120KB, `<title>87 results for Piranesi · OverDrive</title>` |

So: server-rendered results, no key, no token, no library.

## Author handling

Including the author narrows sensibly rather than breaking the search, so it is used when present:

```
q=Piranesi                            -> 87 results
q=Piranesi Susanna Clarke             -> 34 results
q=Parable of the Sower Octavia Butler -> 25 results
```

The bot's schedule stores author as nullable, so a blank one is dropped rather than trailing a space onto the query.

## Endpoint

```
GET /api/libby_url?title=Piranesi&author=Susanna+Clarke
→ {"url":"https://www.overdrive.com/search?q=Piranesi+Susanna+Clarke"}
```

Missing title returns `{"error":"title is required"}`.

**No authentication and no rate limit**, both deliberate: a bot calls it, and it does no I/O — no OverDrive request, no database, no dataset scan. It is string formatting. Throttling it would risk breaking the intended consumer, which will call it once per book in a burst while formatting a reading schedule.

## Testing

13 tests. 7 unit (`libby_url_spec.rb`) covering encoding, blank author, missing title; 6 endpoint (`libby_url_endpoint_spec.rb`) covering the JSON contract and that it works unauthenticated.
