### PR TITLE
Add the anonymous library picker

### DIFF
--- a/lib/route_helpers.rb
+++ b/lib/route_helpers.rb
@@ -55,12 +55,12 @@ module RouteHelpers
   # OverDrive blocks some networks outright, answering the library lookup with a
   # 403 rather than JSON. Send the user back to the zip code form with a message
   # they can act on, instead of letting it surface as a bare 500.
-  def fetch_local_libraries request, zip
+  def fetch_local_libraries request, zip, fallback: nil
     Overdrive.local_libraries zip.delete ' '
   rescue Overdrive::ApiError => e
     Sentry.capture_exception(e) if defined?(Sentry)
     flash[:error] = 'We could not reach OverDrive to look up libraries. Please try again in a little while.'
-    request.redirect @shelf_name ? "/goodreads/shelves/#{@shelf_name}/overdrive" : '/goodreads/shelves'
+    request.redirect fallback || (@shelf_name ? "/goodreads/shelves/#{@shelf_name}/overdrive" : '/goodreads/shelves')
   end
 
   def sort_by_date_added books

--- a/lib/search_routes.rb
+++ b/lib/search_routes.rb
@@ -5,24 +5,77 @@ module SearchRoutes
   def handle_search_routes request
     require_goodreads_session request
 
-    request.on 'shelves' do
-      # route: GET /search/shelves
+    request.on('shelves') { anonymous_shelf_routes request }
+    request.on('library') { anonymous_library_routes request }
+  end
+
+  def anonymous_shelf_routes request
+    # route: GET /search/shelves
+    request.get true do
+      @shelves = Goodreads.fetch_shelves @goodreads_user_id
+      view 'search/shelves'
+    end
+
+    request.on String do |shelf_name|
+      @shelf_name = shelf_name
+      Cache.set session, shelf_name: @shelf_name
+
+      # route: GET /search/shelves/:name
       request.get true do
-        @shelves = Goodreads.fetch_shelves @goodreads_user_id
-        view 'search/shelves'
+        @book_info = anonymous_shelf_books
+        @histogram_dataset = Goodreads.plot_books_over_time @book_info
+        @ratings = Goodreads.rating_stats @book_info
+        view 'shelves/show'
       end
 
-      request.on String do |shelf_name|
-        @shelf_name = shelf_name
-        @book_info = cached_or_fetch(@shelf_name.to_sym) { Goodreads.get_books(@shelf_name, @goodreads_user_id, @anon_access_token) }
-
-        # route: GET /search/shelves/:name
-        request.get true do
-          @histogram_dataset = Goodreads.plot_books_over_time @book_info
-          @ratings = Goodreads.rating_stats @book_info
-          view 'shelves/show'
-        end
+      # route: GET /search/shelves/:name/overdrive
+      #
+      # Renders a zip code form and nothing else, so it deliberately does not
+      # load the shelf -- doing that is what timed out the authenticated
+      # equivalent in #1333.
+      request.get 'overdrive' do
+        @library_action = '/search/library'
+        view 'shelves/overdrive'
       end
     end
+  end
+
+  def anonymous_library_routes request
+    # route: POST /search/library?zipcode=90029
+    request.post true do
+      check_csrf!
+      @shelf_name = Cache.get session, :shelf_name
+      zip = request.params['zipcode'].to_s
+      reject_zip request, 'You need to enter a zip code' if zip.empty?
+      reject_zip request, 'Please try a different zip code' unless Geolocation.known_zip?(zip)
+
+      Cache.set session, libraries: fetch_local_libraries(request, zip, fallback: zip_form_path)
+      request.redirect '/search/library'
+    end
+
+    # route: GET /search/library
+    request.get true do
+      @shelf_name = Cache.get session, :shelf_name
+      @local_libraries = Cache.get session, :libraries
+      unless @local_libraries
+        flash[:error] = @shelf_name ? 'Please enter your zip code first' : 'Please choose a shelf first'
+        request.redirect @shelf_name ? zip_form_path : '/search/shelves'
+      end
+      @availability_action = '/search/availability'
+      view 'library'
+    end
+  end
+
+  def anonymous_shelf_books
+    cached_or_fetch(@shelf_name.to_sym) { Goodreads.get_books(@shelf_name, @goodreads_user_id, @anon_access_token) }
+  end
+
+  def zip_form_path
+    @shelf_name ? "/search/shelves/#{@shelf_name}/overdrive" : '/search/shelves'
+  end
+
+  def reject_zip request, message
+    flash[:error] = message
+    request.redirect zip_form_path
   end
 end

--- a/spec/web/anonymous_search_spec.rb
+++ b/spec/web/anonymous_search_spec.rb
@@ -22,4 +22,20 @@ describe 'Anonymous search flow' do
       assert_current_path '/'
     end
   end
+
+  describe 'GET /search/library' do
+    it 'redirects to / when no session credentials exist' do
+      visit '/search/library'
+
+      assert_current_path '/'
+    end
+  end
+
+  describe 'GET /search/shelves/:name/overdrive' do
+    it 'redirects to / when no session credentials exist' do
+      visit '/search/shelves/to-read/overdrive'
+
+      assert_current_path '/'
+    end
+  end
 end

--- a/views/library.erb
+++ b/views/library.erb
@@ -31,7 +31,8 @@
             <h4 class="text-lg font-medium text-mauve-950"><%= library[1] %></h4>
           </div>
           <div class="ml-4">
-            <form action="/goodreads/shelves/<%= @shelf_name %>/overdrive" method="post">
+            <form action="<%= @availability_action || "/goodreads/shelves/#{@shelf_name}/overdrive" %>" method="post">
+              <% if @availability_action %><%= csrf_tag(@availability_action) %><% end %>
               <input type="hidden" name="consortium" value="<%= library[0] %>">
               <button class="inline-flex items-center justify-center w-10 h-10 bg-mauve-950 hover:bg-mauve-900 text-white rounded-full transition-colors duration-200" type="submit" id="<%= library[0] %>" name="action">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/views/shelves/overdrive.erb
+++ b/views/shelves/overdrive.erb
@@ -13,7 +13,7 @@
 
 <div class="max-w-2xl mx-auto">
   <div class="rounded-xl bg-mauve-950/[.025] p-6">
-    <form action="/libraries" method="post" autocomplete="on">
+    <form action="<%= @library_action || '/libraries' %>" method="post" autocomplete="on">
       <div class="mb-6">
         <label for="zipcode" class="block text-sm font-medium text-mauve-950 mb-2">Enter your zip code:</label>
         <input type="text"


### PR DESCRIPTION
Closes #1258, #1262, #1263. The two steps between choosing a shelf and checking availability, for the anonymous flow.

## Shared views rather than duplicated ones

#1262 asked for a separate `views/search/library.erb`. I didn't create one — it would have been a second copy of the library logo markup and SVG fallback, kept in sync forever, for **one differing form attribute**.

Instead both forms take their action from an instance variable, which is exactly what #1263 already asks for on the other form:

| View | Action | Anonymous sets |
|---|---|---|
| `shelves/overdrive.erb` | `@library_action \|\| '/libraries'` | `/search/library` |
| `library.erb` | `@availability_action \|\| "/goodreads/shelves/…"` | `/search/availability` |

Happy to split it into a real second view if you'd rather, but the duplication seemed like the worse end of the trade.

## Two bugs avoided rather than inherited

**The zip form does not load the shelf.** That is precisely what timed out the authenticated equivalent in #1333. Writing the anonymous route the obvious way would have copied the bug into the new flow before the fix even merged.

**`fetch_local_libraries` no longer hardcodes authenticated redirects.** It previously sent failures to `/goodreads/shelves/…`, which would have dumped an anonymous visitor into the authenticated flow whenever OverDrive was unreachable. It now takes a `fallback:`.

## Security

The new `POST /search/library` calls `check_csrf!` and the view emits a matching token. The authenticated equivalent does neither today — I left that alone rather than changing behaviour on a path this PR isn't about, but it's worth a separate look.

## Testing

Two specs that run without credentials: both new routes redirect to `/` when there are no session credentials. The credential-carrying paths are #1264's job, and that issue is still open.
