### PR TITLE
Stop pairing hidden with another display utility

### DIFF
--- a/spec/lib/view_display_classes_spec.rb
+++ b/spec/lib/view_display_classes_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+# `hidden` is a display utility like any other, so pairing it with `block` or
+# `inline-flex` in one class attribute is a coin flip decided by the order
+# Tailwind emits the rules in -- both selectors carry the same specificity and
+# the later one wins. In the current build `.hidden` lands at byte 11299 and
+# `.inline-flex` at 11355, so `hidden inline-flex` renders *visible*: it left a
+# "Try Again" button on screen through every healthy BookMooch import (#1342)
+# and put a disabled "Sending to BookMooch..." button next to the Authenticate
+# one on the credentials form.
+#
+# Nothing warns about this -- the markup looks right, and the pair that happens
+# to work today (`hidden block`) can flip on a Tailwind upgrade. So assert the
+# combination is absent and let the JS add the display utility when it drops
+# `hidden`.
+DISPLAY_UTILITIES = %w[block inline-block inline flex inline-flex grid inline-grid table inline-table flow-root contents list-item table-row table-cell].freeze
+
+describe 'view display classes' do
+  it 'never pairs hidden with another display utility' do
+    offenders = Dir.glob('views/**/*.erb').flat_map do |file|
+      File.read(file).scan(/class="([^"]*)"/).filter_map do |(attribute)|
+        classes = attribute.split
+        next unless classes.include?('hidden')
+
+        clashing = classes & DISPLAY_UTILITIES
+        "#{file}: `hidden` alongside `#{clashing.join('`, `')}`" unless clashing.empty?
+      end
+    end
+
+    assert_empty offenders, <<~MESSAGE
+      These elements will not hide. Drop the display utility from the class
+      attribute and have the script add it when it removes `hidden`:
+
+      #{offenders.join("\n")}
+    MESSAGE
+  end
+end

--- a/views/_import_toast.erb
+++ b/views/_import_toast.erb
@@ -39,7 +39,11 @@
       <%= progress_label %>
     </a>
     <% end %>
-    <a id="toast-link" href="<%= import_url %>" class="hidden mt-3 block text-center text-sm font-medium text-white bg-gradient-to-r from-indigo-800 to-violet-800 rounded-full px-4 py-2 hover:shadow-md hover:-translate-y-0.5 transition-all duration-300">
+    <%# `block` is added by the swap below rather than sitting here beside `hidden`.
+        The two carry the same specificity, so which one applies is decided by the
+        order Tailwind happens to emit them in -- today `.hidden` lands second and
+        wins, but that is luck, not a guarantee. %>
+    <a id="toast-link" href="<%= import_url %>" class="hidden mt-3 text-center text-sm font-medium text-white bg-gradient-to-r from-indigo-800 to-violet-800 rounded-full px-4 py-2 hover:shadow-md hover:-translate-y-0.5 transition-all duration-300">
       <%= done_label %>
     </a>
   </div>
@@ -64,9 +68,16 @@
           document.getElementById('toast-check').classList.remove('hidden');
           document.getElementById('toast-message').textContent = '<%= done_message %>';
           document.getElementById('toast-subtitle').classList.add('hidden');
+          // Move `block` along with `hidden` -- an element keeping a display
+          // utility is not reliably hidden by the `hidden` class alone.
           var progressLink = document.getElementById('toast-progress-link');
-          if (progressLink) progressLink.classList.add('hidden');
-          document.getElementById('toast-link').classList.remove('hidden');
+          if (progressLink) {
+            progressLink.classList.add('hidden');
+            progressLink.classList.remove('block');
+          }
+          var doneLink = document.getElementById('toast-link');
+          doneLink.classList.remove('hidden');
+          doneLink.classList.add('block');
         }
       })
       .catch(function() {});

--- a/views/bookmooch_progress.erb
+++ b/views/bookmooch_progress.erb
@@ -8,7 +8,7 @@
     <!-- Animated spinner -->
     <div class="flex justify-center mb-6">
       <div class="relative">
-        <div class="w-20 h-20 border-4 border-mauve-200 border-t-mauve-950 rounded-full animate-spin"></div>
+        <div id="import-spinner" class="w-20 h-20 border-4 border-mauve-200 border-t-mauve-950 rounded-full animate-spin"></div>
         <div class="absolute inset-0 flex items-center justify-center">
           <svg class="w-8 h-8 text-mauve-950" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
@@ -21,7 +21,11 @@
     <p class="text-sm text-mauve-500" id="progress-text"></p>
 
     <div id="error-message" class="hidden mt-4 p-4 rounded-xl bg-mauve-950/[.025] border border-mauve-300 text-mauve-950"></div>
-    <a id="retry-button" href="javascript:history.back()" class="hidden mt-6 inline-flex items-center justify-center px-6 py-3 bg-gradient-to-r from-indigo-800 to-violet-800 text-white font-medium rounded-full shadow-md hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300">Try Again</a>
+    <%# No display utility besides `hidden` here: `hidden` and `inline-flex` carry
+        the same specificity, Tailwind emits `.inline-flex` after `.hidden`, and the
+        later rule wins -- so pairing them left this button on screen through every
+        healthy import. showError adds `inline-flex` when it drops `hidden`. %>
+    <a id="retry-button" href="javascript:history.back()" class="hidden mt-6 items-center justify-center px-6 py-3 bg-gradient-to-r from-indigo-800 to-violet-800 text-white font-medium rounded-full shadow-md hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300">Try Again</a>
   </div>
 </div>
 
@@ -35,6 +39,18 @@
   const progressBar = document.getElementById('progress-bar');
   const progressText = document.getElementById('progress-text');
   const errorMessage = document.getElementById('error-message');
+  const retryButton = document.getElementById('retry-button');
+  // By id, not '.animate-spin': the import toast renders above this page's
+  // content, so a document-wide query stops the toast's spinner instead.
+  const spinner = document.getElementById('import-spinner');
+
+  function showError(message) {
+    errorMessage.textContent = message;
+    errorMessage.classList.remove('hidden');
+    retryButton.classList.remove('hidden');
+    retryButton.classList.add('inline-flex');
+    spinner.style.display = 'none';
+  }
 
   console.log('Connecting to WebSocket:', wsUrl);
   const ws = new WebSocket(wsUrl);
@@ -75,10 +91,7 @@
         break;
 
       case 'error':
-        errorMessage.textContent = data.message;
-        errorMessage.classList.remove('hidden');
-        document.getElementById('retry-button').classList.remove('hidden');
-        document.querySelector('.animate-spin').style.display = 'none';
+        showError(data.message);
         statusMessage.textContent = 'An error occurred';
         break;
     }
@@ -86,10 +99,7 @@
 
   ws.onerror = function(error) {
     console.error('WebSocket error:', error);
-    errorMessage.textContent = 'Connection error. Please try again.';
-    errorMessage.classList.remove('hidden');
-    document.getElementById('retry-button').classList.remove('hidden');
-    document.querySelector('.animate-spin').style.display = 'none';
+    showError('Connection error. Please try again.');
     statusMessage.textContent = 'Connection failed';
   };
 

--- a/views/shelves/bookmooch.erb
+++ b/views/shelves/bookmooch.erb
@@ -75,7 +75,11 @@
             Authenticate
           </button>
 
-          <button class="sending-btn hidden w-full inline-flex items-center justify-center px-6 py-3 bg-mauve-300 text-mauve-950 font-medium rounded-full"
+          <%# `inline-flex` is added by the swap below rather than sitting here beside
+              `hidden`. The two carry the same specificity and Tailwind emits
+              `.inline-flex` last, so together they left this button on screen next to
+              the Authenticate one from the moment the page loaded. %>
+          <button class="sending-btn hidden w-full items-center justify-center px-6 py-3 bg-mauve-300 text-mauve-950 font-medium rounded-full"
                   type="button"
                   disabled>
             <svg class="w-5 h-5 mr-2 animate-spin" fill="none" viewBox="0 0 24 24">
@@ -94,8 +98,13 @@
   var oldbutton = document.getElementsByClassName('authenticate-btn')[0];
   var newbutton = document.getElementsByClassName('sending-btn')[0];
 
+  // Move `inline-flex` along with `hidden`. Adding `hidden` on its own does not
+  // hide an element that also carries a display utility -- Tailwind emits
+  // `.inline-flex` after `.hidden`, so the later rule wins.
   oldbutton.onclick = function(){
     newbutton.classList.remove('hidden');
+    newbutton.classList.add('inline-flex');
     oldbutton.classList.add('hidden');
+    oldbutton.classList.remove('inline-flex');
   };
 </script>


### PR DESCRIPTION
Closes #1342.

## Cause

`hidden` is a display utility like any other. `class="hidden inline-flex"` puts two rules of equal specificity on one element, so the one Tailwind emits last wins:

```
$ bundle exec rake tailwind:build          # tailwindcss v4.3.3
$ grep -bo '\.block{display:block' assets/css/styles.css          # 11240
$ grep -bo '\.hidden{display:none' assets/css/styles.css          # 11299
$ grep -bo '\.inline-flex{display:inline-flex' assets/css/styles.css   # 11355
```

`hidden inline-flex` renders **visible**, and `classList.remove('hidden')` has nothing left to do. Nothing warns about it — the markup reads correctly.

## What was showing

| Element | Symptom |
|---|---|
| `#retry-button`, progress page | "Try Again" on screen through every healthy import |
| `.sending-btn`, credentials form | disabled "Sending to BookMooch…" beside Authenticate from first paint |
| `.authenticate-btn`, credentials form | clicking it could not hide it either — same reason |
| `#toast-link`, import toast | correct today, by luck |

The first one is what made a still-running import look like a failed one while debugging #1337 — the CI page dump showed "Try Again" under a progress message, which reads as an error state and was not one.

`#toast-link` pairs `hidden block`, and `.block` happens to be emitted *before* `.hidden`. That is a coin that landed the right way up; a Tailwind upgrade can reorder it. It moves to the same footing as the others rather than staying a latent one.

## Fix

The display utility goes on and comes off together with `hidden`, in whichever script does the swap. Nothing relies on emission order any more.

## Guard

`spec/lib/view_display_classes_spec.rb` walks `views/**/*.erb` and fails on the combination. It is not a hypothetical: on the parent commit it names all three.

```
views/_import_toast.erb: `hidden` alongside `block`
views/bookmooch_progress.erb: `hidden` alongside `inline-flex`
views/shelves/bookmooch.erb: `hidden` alongside `inline-flex`
```

No network, no browser, runs in 3ms.

## Also here

`views/bookmooch_progress.erb` looked its spinner up with `document.querySelector('.animate-spin')`. `views/layout.erb` renders the import toast at line 200 and `yield` at 203, so the toast's spinner is first in the document — on error the toast's spinner stopped and the page's own kept spinning under the error message. Now looked up by id.

## Verification

Templates compile under Tilt and the `<%# %>` comments are stripped from the compiled source rather than emitted. `spec/lib` is otherwise unchanged — the three errors it shows locally are missing `GOODREADS_API_KEY` / `OVERDRIVE_KEY` from having no `.env`, and are present on `main` too.