### PR TITLE
Wait for the alternate ISBN lookups, not just their scheduling

### DIFF
--- a/lib/alternate_isbns.rb
+++ b/lib/alternate_isbns.rb
@@ -67,7 +67,13 @@ module AlternateIsbns
 
       uncached_isbns.each do |isbn|
         semaphore.async do
-          limiter.async do
+          # Wait on the limiter's task rather than just spawning it. Only the
+          # semaphore tasks are registered with the barrier, so without this a
+          # semaphore task finishes the moment its child is scheduled and
+          # `barrier.wait` returns on work that is still in flight -- dropping
+          # the alternates for whichever books were mid-request, and leaving
+          # orphans to report progress after the caller has moved on.
+          fetch_task = limiter.async do
             alternates, work_key = fetch_alternates_for_isbn_with_retry(isbn)
             result[isbn] = alternates unless alternates.empty?
             IsbnAlternate.store(isbn, alternates, work_key: work_key)
@@ -77,6 +83,8 @@ module AlternateIsbns
             completed_count += 1
             report_progress(progress_callback, completed_count, total_isbns)
           end
+
+          fetch_task.wait
         end
       end
 

--- a/spec/lib/alternate_isbns_completeness_spec.rb
+++ b/spec/lib/alternate_isbns_completeness_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+require 'database'
+
+# Run migrations before loading models (model introspects table at load time)
+Sequel.extension :migration
+Sequel::Migrator.run(DB, 'db/migrations')
+
+require 'alternate_isbns'
+require 'models/isbn_alternate'
+
+COMPLETENESS_ISBNS = %w[9780140328721 9780140328722 9780140328723 9780140328724 9780140328725 9780140328726].freeze
+
+# The lookup has to actually suspend for this to reproduce anything: a stub that
+# returns without yielding leaves no task in flight for `barrier.wait` to return
+# early on. Two seconds against a 1.4/sec limiter keeps several outstanding at
+# the moment the last one is admitted.
+SLOW_LOOKUP = ->(isbn) {
+  sleep 2
+  [["alt-#{isbn}"], "work-#{isbn}"]
+}
+
+# Only the semaphore tasks are registered with the barrier, and a semaphore task
+# used to finish as soon as it had *scheduled* its limiter child. So
+# `barrier.wait` returned on work still in flight: against Open Library it came
+# back with 19 of 21 books filled in and the rest arrived seconds later, into a
+# hash the caller had already read.
+#
+# Standalone that is invisible -- `Sync` outside a reactor runs one to
+# completion, so the children finish before the method returns. It only shows
+# under Falcon, where we are already in a reactor and `Sync` runs inline. Hence
+# the `Async` wrapper here: without it this passes on the broken code.
+describe 'AlternateIsbns completeness' do
+  before do
+    DB[:isbn_alternates].delete
+  end
+
+  # Both snapshots are taken inside the reactor, at the instant the method
+  # returns, because that is when its caller reads them -- Bookmooch hands the
+  # hash straight to expand_isbns_with_alternates. Reading after the reactor has
+  # drained would show the orphans' late writes and pass either way.
+  it 'returns every requested ISBN when called from inside a reactor' do
+    observed = nil
+    AlternateIsbns.stub(:fetch_alternates_for_isbn_with_retry, SLOW_LOOKUP) do
+      Async { observed = AlternateIsbns.fetch_alternate_isbns(COMPLETENESS_ISBNS).keys.sort }.wait
+    end
+
+    assert_equal COMPLETENESS_ISBNS.sort, observed
+  end
+
+  it 'reports progress for every ISBN before it returns' do
+    reported = []
+    collect = ->(update) { reported << update[:current] if update[:type] == 'progress' }
+
+    furthest = nil
+    AlternateIsbns.stub(:fetch_alternates_for_isbn_with_retry, SLOW_LOOKUP) do
+      task = Async do
+        AlternateIsbns.fetch_alternate_isbns(COMPLETENESS_ISBNS, &collect)
+        furthest = reported.max
+      end
+      task.wait
+    end
+
+    # Late progress messages are what overwrote "Sending N ISBNs to BookMooch..."
+    # on the import page with a stale "Fetching alternate ISBNs" line.
+    assert_equal COMPLETENESS_ISBNS.size, furthest, 'progress stopped short of the last ISBN'
+  end
+end

--- a/spec/lib/view_display_classes_spec.rb
+++ b/spec/lib/view_display_classes_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+# `hidden` is a display utility like any other, so pairing it with `block` or
+# `inline-flex` in one class attribute is a coin flip decided by the order
+# Tailwind emits the rules in -- both selectors carry the same specificity and
+# the later one wins. In the current build `.hidden` lands at byte 11299 and
+# `.inline-flex` at 11355, so `hidden inline-flex` renders *visible*: it left a
+# "Try Again" button on screen through every healthy BookMooch import (#1342)
+# and put a disabled "Sending to BookMooch..." button next to the Authenticate
+# one on the credentials form.
+#
+# Nothing warns about this -- the markup looks right, and the pair that happens
+# to work today (`hidden block`) can flip on a Tailwind upgrade. So assert the
+# combination is absent and let the JS add the display utility when it drops
+# `hidden`.
+DISPLAY_UTILITIES = %w[block inline-block inline flex inline-flex grid inline-grid table inline-table flow-root contents list-item table-row table-cell].freeze
+
+describe 'view display classes' do
+  it 'never pairs hidden with another display utility' do
+    offenders = Dir.glob('views/**/*.erb').flat_map do |file|
+      File.read(file).scan(/class="([^"]*)"/).filter_map do |(attribute)|
+        classes = attribute.split
+        next unless classes.include?('hidden')
+
+        clashing = classes & DISPLAY_UTILITIES
+        "#{file}: `hidden` alongside `#{clashing.join('`, `')}`" unless clashing.empty?
+      end
+    end
+
+    assert_empty offenders, <<~MESSAGE
+      These elements will not hide. Drop the display utility from the class
+      attribute and have the script add it when it removes `hidden`:
+
+      #{offenders.join("\n")}
+    MESSAGE
+  end
+end

--- a/views/_import_toast.erb
+++ b/views/_import_toast.erb
@@ -39,7 +39,11 @@
       <%= progress_label %>
     </a>
     <% end %>
-    <a id="toast-link" href="<%= import_url %>" class="hidden mt-3 block text-center text-sm font-medium text-white bg-gradient-to-r from-indigo-800 to-violet-800 rounded-full px-4 py-2 hover:shadow-md hover:-translate-y-0.5 transition-all duration-300">
+    <%# `block` is added by the swap below rather than sitting here beside `hidden`.
+        The two carry the same specificity, so which one applies is decided by the
+        order Tailwind happens to emit them in -- today `.hidden` lands second and
+        wins, but that is luck, not a guarantee. %>
+    <a id="toast-link" href="<%= import_url %>" class="hidden mt-3 text-center text-sm font-medium text-white bg-gradient-to-r from-indigo-800 to-violet-800 rounded-full px-4 py-2 hover:shadow-md hover:-translate-y-0.5 transition-all duration-300">
       <%= done_label %>
     </a>
   </div>
@@ -64,9 +68,16 @@
           document.getElementById('toast-check').classList.remove('hidden');
           document.getElementById('toast-message').textContent = '<%= done_message %>';
           document.getElementById('toast-subtitle').classList.add('hidden');
+          // Move `block` along with `hidden` -- an element keeping a display
+          // utility is not reliably hidden by the `hidden` class alone.
           var progressLink = document.getElementById('toast-progress-link');
-          if (progressLink) progressLink.classList.add('hidden');
-          document.getElementById('toast-link').classList.remove('hidden');
+          if (progressLink) {
+            progressLink.classList.add('hidden');
+            progressLink.classList.remove('block');
+          }
+          var doneLink = document.getElementById('toast-link');
+          doneLink.classList.remove('hidden');
+          doneLink.classList.add('block');
         }
       })
       .catch(function() {});

--- a/views/bookmooch_progress.erb
+++ b/views/bookmooch_progress.erb
@@ -8,7 +8,7 @@
     <!-- Animated spinner -->
     <div class="flex justify-center mb-6">
       <div class="relative">
-        <div class="w-20 h-20 border-4 border-mauve-200 border-t-mauve-950 rounded-full animate-spin"></div>
+        <div id="import-spinner" class="w-20 h-20 border-4 border-mauve-200 border-t-mauve-950 rounded-full animate-spin"></div>
         <div class="absolute inset-0 flex items-center justify-center">
           <svg class="w-8 h-8 text-mauve-950" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
@@ -21,7 +21,11 @@
     <p class="text-sm text-mauve-500" id="progress-text"></p>
 
     <div id="error-message" class="hidden mt-4 p-4 rounded-xl bg-mauve-950/[.025] border border-mauve-300 text-mauve-950"></div>
-    <a id="retry-button" href="javascript:history.back()" class="hidden mt-6 inline-flex items-center justify-center px-6 py-3 bg-gradient-to-r from-indigo-800 to-violet-800 text-white font-medium rounded-full shadow-md hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300">Try Again</a>
+    <%# No display utility besides `hidden` here: `hidden` and `inline-flex` carry
+        the same specificity, Tailwind emits `.inline-flex` after `.hidden`, and the
+        later rule wins -- so pairing them left this button on screen through every
+        healthy import. showError adds `inline-flex` when it drops `hidden`. %>
+    <a id="retry-button" href="javascript:history.back()" class="hidden mt-6 items-center justify-center px-6 py-3 bg-gradient-to-r from-indigo-800 to-violet-800 text-white font-medium rounded-full shadow-md hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300">Try Again</a>
   </div>
 </div>
 
@@ -35,6 +39,18 @@
   const progressBar = document.getElementById('progress-bar');
   const progressText = document.getElementById('progress-text');
   const errorMessage = document.getElementById('error-message');
+  const retryButton = document.getElementById('retry-button');
+  // By id, not '.animate-spin': the import toast renders above this page's
+  // content, so a document-wide query stops the toast's spinner instead.
+  const spinner = document.getElementById('import-spinner');
+
+  function showError(message) {
+    errorMessage.textContent = message;
+    errorMessage.classList.remove('hidden');
+    retryButton.classList.remove('hidden');
+    retryButton.classList.add('inline-flex');
+    spinner.style.display = 'none';
+  }
 
   console.log('Connecting to WebSocket:', wsUrl);
   const ws = new WebSocket(wsUrl);
@@ -75,10 +91,7 @@
         break;
 
       case 'error':
-        errorMessage.textContent = data.message;
-        errorMessage.classList.remove('hidden');
-        document.getElementById('retry-button').classList.remove('hidden');
-        document.querySelector('.animate-spin').style.display = 'none';
+        showError(data.message);
         statusMessage.textContent = 'An error occurred';
         break;
     }
@@ -86,10 +99,7 @@
 
   ws.onerror = function(error) {
     console.error('WebSocket error:', error);
-    errorMessage.textContent = 'Connection error. Please try again.';
-    errorMessage.classList.remove('hidden');
-    document.getElementById('retry-button').classList.remove('hidden');
-    document.querySelector('.animate-spin').style.display = 'none';
+    showError('Connection error. Please try again.');
     statusMessage.textContent = 'Connection failed';
   };
 

--- a/views/shelves/bookmooch.erb
+++ b/views/shelves/bookmooch.erb
@@ -75,7 +75,11 @@
             Authenticate
           </button>
 
-          <button class="sending-btn hidden w-full inline-flex items-center justify-center px-6 py-3 bg-mauve-300 text-mauve-950 font-medium rounded-full"
+          <%# `inline-flex` is added by the swap below rather than sitting here beside
+              `hidden`. The two carry the same specificity and Tailwind emits
+              `.inline-flex` last, so together they left this button on screen next to
+              the Authenticate one from the moment the page loaded. %>
+          <button class="sending-btn hidden w-full items-center justify-center px-6 py-3 bg-mauve-300 text-mauve-950 font-medium rounded-full"
                   type="button"
                   disabled>
             <svg class="w-5 h-5 mr-2 animate-spin" fill="none" viewBox="0 0 24 24">
@@ -94,8 +98,13 @@
   var oldbutton = document.getElementsByClassName('authenticate-btn')[0];
   var newbutton = document.getElementsByClassName('sending-btn')[0];
 
+  // Move `inline-flex` along with `hidden`. Adding `hidden` on its own does not
+  // hide an element that also carries a display utility -- Tailwind emits
+  // `.inline-flex` after `.hidden`, so the later rule wins.
   oldbutton.onclick = function(){
     newbutton.classList.remove('hidden');
+    newbutton.classList.add('inline-flex');
     oldbutton.classList.add('hidden');
+    oldbutton.classList.remove('inline-flex');
   };
 </script>


### PR DESCRIPTION
Closes #1343.

## Cause

`fetch_uncached_isbns` nests a limiter task inside a semaphore task, and only the semaphore tasks are registered with the barrier:

```ruby
semaphore = Async::Semaphore.new(4, parent: barrier)

semaphore.async do
  limiter.async do   # <- spawned, never awaited
    ...
  end
end

barrier.wait
```

A semaphore task finished as soon as its child was *scheduled*, so `barrier.wait` returned on work still in flight.

## Measured, not assumed

21 books against Open Library, cold cache, three runs:

```
run 1: returned 13.0s with 19/21 books; orphaned tasks then brought it to 21/21
run 2: returned 13.0s with 19/21 books; orphaned tasks then brought it to 21/21
run 3: returned 13.0s with 19/21 books; orphaned tasks then brought it to 21/21
```

The last two books' alternates land seconds after `Bookmooch` has already passed the hash to `expand_isbns_with_alternates`. Those books reach BookMooch with no alternate editions — the matching this module exists to do.

I originally wrote in #1343 that this made the feature a no-op. That was from a synthetic repro running the limiter at 5/sec; at the real 1.4/sec, `limiter.async` blocks on admission and paces the semaphore tasks ~0.7s apart, so only the tail is lost. Corrected [in the issue](https://github.com/stephaniewilkinson/yonderbook/issues/1343#issuecomment-5463285679).

The orphans also keep calling `progress_callback` after the caller has moved on. That is what overwrote `"Sending N ISBNs to BookMooch..."` with a stale `"Fetching alternate ISBNs — 21 of 21 complete"` — the exact state the #1337 CI failure was dumped in, and why a running import read as a stuck one.

## Cost

| | as shipped | this PR |
|---|---|---|
| elapsed | 13.0s | 14.9s |
| books with alternates | 19/21 | 21/21 |
| expanded ISBNs | 1187 | 1275 |
| BookMooch batches | 9 | 10 |

I flagged in #1343 that this might need the lookup bounded to stay affordable. It does not — the limiter already paces admission, so awaiting adds ~2s. One extra BookMooch batch.

## Why the spec is shaped that way

None of this reproduces standalone: `Sync` outside a reactor runs one to completion, so the children finish before the method returns. It needs Falcon, where we are already in a reactor and `Sync` runs inline.

So the spec wraps the call in `Async` and — this part matters — snapshots **inside** the reactor, at the instant the method returns, because that is where the caller reads. My first attempt asserted after `Async{}.wait` and passed on the broken code, since the reactor had drained the orphans by then.

The stub also has to actually suspend; one that returns without yielding leaves nothing in flight to return early on.

Both cases fail on the parent commit:

```
1) Failure: returns every requested ISBN when called from inside a reactor
2) Failure: progress stopped short of the last ISBN.  Expected: 6
```

and pass here. ~8.5s, no network.