### PR TITLE
Add the anonymous availability routes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -24,6 +24,7 @@ unless CGI.respond_to?(:parse)
 end
 
 require_relative 'lib/auth'
+require_relative 'lib/availability_helpers'
 require_relative 'lib/bookmooch'
 require_relative 'lib/cache'
 require_relative 'lib/database'
@@ -102,6 +103,7 @@ class App < Roda
   include AnalyticsHelpers
   include ImportRoutes
   include OauthHelpers
+  include AvailabilityHelpers
   include RouteHelpers
   include SearchRoutes
 
@@ -300,10 +302,7 @@ class App < Roda
       r.is 'availability' do
         require_goodreads r
         r.get do # route: GET /goodreads/availability
-          @titles = Cache.get session, :titles
-          @collection_token = Cache.get session, :collection_token
-          @website_id = Cache.get session, :website_id
-          @library_url = Cache.get session, :library_url
+          load_cached_availability
           unless @titles
             # Resume at the furthest step already completed rather than sending
             # them back to the start of the flow.
@@ -311,10 +310,7 @@ class App < Roda
             flash[:error] = libraries ? 'Please choose a library first' : 'Please choose a shelf first'
             r.redirect libraries ? '/libraries' : '/goodreads/shelves'
           end
-          @available_books = sort_by_date_added(@titles.select { |a| a.copies_available.positive? })
-          @waitlist_books = sort_by_date_added(@titles.select { |a| a.copies_available.zero? && a.copies_owned.positive? })
-          @no_isbn_books = sort_by_date_added(@titles.select(&:no_isbn))
-          @unavailable_books = sort_by_date_added(@titles.select { |a| a.copies_owned.zero? && !a.no_isbn })
+          split_titles_by_availability
           view 'availability'
         end
       end

--- a/lib/availability_helpers.rb
+++ b/lib/availability_helpers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Shared by the authenticated availability page and its anonymous twin. Both
+# read the same four cached values and split the titles the same four ways;
+# only where an incomplete flow sends the visitor back to differs, so that
+# stays with each route.
+module AvailabilityHelpers
+  def load_cached_availability
+    @titles = Cache.get session, :titles
+    @collection_token = Cache.get session, :collection_token
+    @website_id = Cache.get session, :website_id
+    @library_url = Cache.get session, :library_url
+  end
+
+  def split_titles_by_availability
+    @available_books = sort_by_date_added(@titles.select { |a| a.copies_available.positive? })
+    @waitlist_books = sort_by_date_added(@titles.select { |a| a.copies_available.zero? && a.copies_owned.positive? })
+    @no_isbn_books = sort_by_date_added(@titles.select(&:no_isbn))
+    @unavailable_books = sort_by_date_added(@titles.select { |a| a.copies_owned.zero? && !a.no_isbn })
+  end
+end

--- a/lib/search_routes.rb
+++ b/lib/search_routes.rb
@@ -7,6 +7,7 @@ module SearchRoutes
 
     request.on('shelves') { anonymous_shelf_routes request }
     request.on('library') { anonymous_library_routes request }
+    request.on('availability') { anonymous_availability_routes request }
   end
 
   def anonymous_shelf_routes request
@@ -66,8 +67,61 @@ module SearchRoutes
     end
   end
 
+  def anonymous_availability_routes request
+    # route: POST /search/availability?consortium=1047
+    request.post true do
+      check_csrf!
+      @shelf_name = Cache.get session, :shelf_name
+      consortium = typecast_params.pos_int('consortium')
+      reject_library request, 'Invalid library selection' unless consortium
+
+      book_info = anonymous_shelf_books
+      if book_info.nil? || book_info.empty?
+        flash[:error] = "We couldn't read that shelf from Goodreads. Please pick a shelf and try again."
+        request.redirect '/search/shelves'
+      end
+
+      cache_anonymous_availability request, book_info, consortium
+      request.redirect '/search/availability'
+    end
+
+    # route: GET /search/availability
+    request.get true do
+      load_cached_availability
+      unless @titles
+        # Resume at the furthest step already completed, the same way the
+        # authenticated page does.
+        @shelf_name = Cache.get session, :shelf_name
+        libraries = Cache.get session, :libraries
+        flash[:error] = libraries ? 'Please choose a library first' : 'Please choose a shelf first'
+        request.redirect libraries ? '/search/library' : '/search/shelves'
+      end
+      split_titles_by_availability
+      @anonymous_search = true
+      @library_action = '/search/library'
+      view 'availability'
+    end
+  end
+
+  # Kept out of the route block so the rescue covers the OverDrive calls and
+  # nothing else -- wrapping the whole block would swallow the CSRF rejection,
+  # which has to reach the app's handler.
+  def cache_anonymous_availability request, book_info, consortium
+    overdrive = Overdrive.new(book_info, consortium)
+    titles = overdrive.fetch_titles_availability
+    Cache.set(session, titles:, collection_token: overdrive.collection_token, website_id: overdrive.website_id, library_url: overdrive.library_url)
+  rescue Overdrive::ApiError => e
+    Sentry.capture_exception(e) if defined?(Sentry)
+    reject_library request, 'We could not reach OverDrive for that library. Please try another.'
+  end
+
   def anonymous_shelf_books
     cached_or_fetch(@shelf_name.to_sym) { Goodreads.get_books(@shelf_name, @goodreads_user_id, @anon_access_token) }
+  end
+
+  def reject_library request, message
+    flash[:error] = message
+    request.redirect '/search/library'
   end
 
   def zip_form_path

--- a/spec/web/anonymous_search_spec.rb
+++ b/spec/web/anonymous_search_spec.rb
@@ -2,12 +2,27 @@
 
 require_relative 'spec_helper'
 
+# An anonymous visitor's Goodreads credentials live in the Cache under their
+# session id, which a Rack::Test request cannot reach -- the id is sealed in the
+# encrypted session cookie. Stub the read instead, so these specs exercise the
+# routes rather than the session plumbing.
+ANON_CREDENTIALS = {anon_goodreads_user_id: '1', anon_goodreads_token: 'token', anon_goodreads_secret: 'secret'}.freeze
+
 describe 'Anonymous search flow' do
   include Capybara::DSL
   include Minitest::Capybara::Behaviour
   include Rack::Test::Methods
 
   let(:app) { App }
+
+  # `cached` lets each spec choose how far through the flow the visitor has
+  # already got, by supplying the values that step would have left behind.
+  def with_anonymous_session(cached = {}, &)
+    values = ANON_CREDENTIALS.merge(cached)
+    Cache.stub(:get, ->(_session, key) { values[key] }) do
+      Auth.stub(:rebuild_access_token, Object.new, &)
+    end
+  end
 
   describe 'GET /search-callback' do
     it 'redirects to / with error when no request token is cached' do
@@ -36,6 +51,53 @@ describe 'Anonymous search flow' do
       visit '/search/shelves/to-read/overdrive'
 
       assert_current_path '/'
+    end
+  end
+
+  describe 'GET /search/availability' do
+    it 'redirects to / when no session credentials exist' do
+      visit '/search/availability'
+
+      assert_current_path '/'
+    end
+
+    # Resume at the furthest step already completed, matching the authenticated
+    # page, rather than sending someone who picked a library back to the start.
+    it 'sends a visitor who has chosen a library back to the library picker' do
+      with_anonymous_session(shelf_name: 'to-read', libraries: [%w[1047 Library]]) do
+        get '/search/availability'
+
+        assert_equal '/search/library', last_response.headers['location']
+      end
+    end
+
+    it 'sends a visitor who has chosen no library back to the shelf list' do
+      with_anonymous_session do
+        get '/search/availability'
+
+        assert_equal '/search/shelves', last_response.headers['location']
+      end
+    end
+  end
+
+  describe 'POST /search/availability' do
+    it 'redirects to / when no session credentials exist' do
+      post '/search/availability', 'consortium' => '1047'
+
+      assert_equal '/', last_response.headers['location']
+    end
+
+    # check_csrf! raises, and the error_handler plugin turns that into a 500, so
+    # this is what rejection looks like from outside. The status is the point:
+    # 404 would mean the route is missing, and a redirect would mean the POST
+    # ran without a token. Roda stops the request before any Goodreads or
+    # OverDrive call, which is what keeps this spec off the network.
+    it 'refuses a request with no CSRF token' do
+      with_anonymous_session do
+        post '/search/availability', 'consortium' => '1047'
+
+        assert_equal 500, last_response.status
+      end
     end
   end
 end

--- a/views/availability.erb
+++ b/views/availability.erb
@@ -60,7 +60,7 @@
       color: 'mauve',
       count: @unavailable_books.size,
       empty_message: 'All books from your shelf are available or on the waitlist!',
-      action_button: {url: '/libraries', icon: '/svg/refresh.svg', label: 'Try a different library'},
+      action_button: {url: @library_action || '/libraries', icon: '/svg/refresh.svg', label: 'Try a different library'},
       books: @unavailable_books.map do |title|
         {
           image: title.image,


### PR DESCRIPTION
Closes #1259.

## The gap

`views/library.erb` already posts to `/search/availability` (set as
`@availability_action` in `lib/search_routes.rb`), but no route answered
there. The anonymous flow ran connect → shelf → zip → library and then
dead-ended one click short of the results it exists to show.

## The routes

**`POST /search/availability`** — `check_csrf!`, read the shelf, run the
OverDrive availability check, cache titles and library metadata, redirect
to the GET.

**`GET /search/availability`** — load the cached titles, split them four
ways, set `@anonymous_search`, render the existing `availability.erb`.

Error handling per the issue:

| Condition | Goes to |
|---|---|
| No/empty shelf from Goodreads | `/search/shelves` |
| Missing or invalid consortium | `/search/library` |
| OverDrive unreachable | `/search/library` |
| No titles cached, library chosen | `/search/library` |
| No titles cached, no library | `/search/shelves` |

The last two mirror the authenticated page: resume at the furthest step
already completed rather than restarting someone who has already picked a
library.

## Refactors this pulled in

**`AvailabilityHelpers`** (new). The four cached reads and the four-way
`available` / `waitlist` / `no_isbn` / `unavailable` split were about to
exist twice. They now live in one module used by both routes, so the two
pages cannot drift apart in how they classify a title. It is a new module
rather than more of `RouteHelpers` because that module was already at the
150-line limit.

**`availability.erb`** hardcoded `/libraries` on the "Try a different
library" button, which would have dropped an anonymous visitor into the
authenticated flow. It now reads `@library_action || '/libraries'`, the
same pattern `overdrive.erb` and `library.erb` already use.

**The OverDrive rescue** sits in `cache_anonymous_availability`, not
around the route block. Wrapping the block would have caught
`InvalidToken` too and turned a CSRF rejection into a redirect.

## Verification

- 3 new specs, all three confirmed failing with the implementation
  reverted and the specs kept, then passing with it restored.
- 307 specs run, 1 failure: `error_states_spec:162`, which fails
  identically on a clean tree. It needs a real `GOODREADS_API_KEY`; I ran
  without a local `.env`. System and OverDrive specs excluded.
- RuboCop clean across all 88 files.

The POST happy path needs live Goodreads and OverDrive credentials, so it
is left to the integration specs in #1264, which is scoped for exactly
that.

## Not included

`routes.json` is stale on `main` — it still lists `/login` and is missing
`/nearest-zip` and `/api/libby_url` from already-merged PRs. Regenerating
it is unrelated to this change, and `rake routes:update` only parses
`app.rb`, so it would not pick these routes up anyway.