### PR TITLE
Carry anonymous Goodreads credentials into a new account

### DIFF
--- a/lib/rodauth_config.rb
+++ b/lib/rodauth_config.rb
@@ -82,6 +82,26 @@ class RodauthConfig < Rodauth::Auth
     # Store email in session after account creation for the interstitial page
     after_create_account do
       session['pending_email'] = account[login_column]
+
+      # A visitor can connect Goodreads before signing up. Those credentials sit
+      # in the session cache, which dies with the session, so copy them onto the
+      # account or the connection is silently lost at the moment they commit.
+      #
+      # The cache entries stay put: they still have to verify their email, and
+      # the anonymous flow has to keep working until they do.
+      goodreads_user_id = Cache.get(session, :anon_goodreads_user_id)
+      token = Cache.get(session, :anon_goodreads_token)
+      secret = Cache.get(session, :anon_goodreads_secret)
+
+      if goodreads_user_id && token && secret
+        begin
+          Goodreads.save_goodreads_connection(account[account_id_column], goodreads_user_id, token, secret)
+        rescue StandardError => e
+          # Never cost someone the account they actually asked for -- they can
+          # reconnect from /connections.
+          Sentry.capture_exception(e) if defined?(Sentry)
+        end
+      end
     end
 
     # Email configuration

--- a/spec/web/anonymous_search_spec.rb
+++ b/spec/web/anonymous_search_spec.rb
@@ -76,6 +76,53 @@ describe 'Anonymous search flow' do
     end
   end
 
+  # Someone can connect Goodreads before they have an account. Those credentials
+  # live in the session cache, which dies with the session, so signing up has to
+  # copy them onto the account or the connection is silently lost.
+  describe 'account creation with anonymous Goodreads credentials' do
+    def sign_up email
+      visit '/sign-up'
+      fill_in 'Email', with: email
+      fill_in 'Password', with: 'SecurePassword123!'
+      click_button 'Create Account'
+    end
+
+    it 'copies the session credentials onto the new account' do
+      email = "migrate_#{Time.now.to_i}_#{rand(9999)}@example.com"
+      with_anonymous_session { sign_up email }
+
+      account = DB[:accounts].where(email: email).first
+      refute_nil account, 'the account was not created'
+      connection = DB[:goodreads_connections].where(user_id: account[:id]).first
+
+      refute_nil connection, 'the Goodreads connection was not migrated'
+      assert_equal ANON_CREDENTIALS[:anon_goodreads_user_id], connection[:goodreads_user_id]
+      assert_equal ANON_CREDENTIALS[:anon_goodreads_token], connection[:access_token]
+    end
+
+    # They can always reconnect from /connections, so a failed migration must not
+    # cost them the account they actually asked for.
+    it 'still creates the account when the migration raises' do
+      email = "migrate_fail_#{Time.now.to_i}_#{rand(9999)}@example.com"
+      exploding = ->(*) { raise 'Goodreads is unreachable' }
+
+      with_anonymous_session do
+        Goodreads.stub(:save_goodreads_connection, exploding) { sign_up email }
+      end
+
+      refute_nil DB[:accounts].where(email: email).first, 'the account was not created'
+    end
+
+    it 'leaves accounts without session credentials alone' do
+      email = "no_migrate_#{Time.now.to_i}_#{rand(9999)}@example.com"
+      sign_up email
+
+      account = DB[:accounts].where(email: email).first
+      refute_nil account, 'the account was not created'
+      assert_empty DB[:goodreads_connections].where(user_id: account[:id]).all
+    end
+  end
+
   describe 'GET /search/availability' do
     it 'redirects to / when no session credentials exist' do
       visit '/search/availability'


### PR DESCRIPTION
Closes #1270.

## The loss

A visitor can connect Goodreads before signing up — that is the whole
point of the anonymous flow. `store_goodreads_in_session` puts the
credentials in the session cache, and `after_create_account` did not look
at them.

So the connection died at the moment the visitor committed to keeping it.
They finished signup, landed on a fresh account with nothing connected,
and got no indication anything had gone missing.

## The fix

`after_create_account` is extended, not replaced — the existing
`pending_email` assignment is untouched:

```ruby
goodreads_user_id = Cache.get(session, :anon_goodreads_user_id)
token = Cache.get(session, :anon_goodreads_token)
secret = Cache.get(session, :anon_goodreads_secret)

if goodreads_user_id && token && secret
  begin
    Goodreads.save_goodreads_connection(account[account_id_column], goodreads_user_id, token, secret)
  rescue StandardError => e
    Sentry.capture_exception(e) if defined?(Sentry)
  end
end
```

**The cache entries stay.** Verification comes next and the anonymous flow
has to keep working until they finish it, so clearing them here would
break the visitor's session to tidy up state that expires on its own.

**The save is wrapped** because it reaches the database and can fail for
reasons unrelated to the signup in front of it. Losing the connection is
recoverable from `/connections`; losing the account is not.

**`account[account_id_column]`** rather than `account[:id]`, so it follows
the Rodauth config rather than assuming the column name.

## Acceptance criteria

- [x] `after_create_account` extended, not replaced
- [x] Connection saved when session credentials exist
- [x] Account creation succeeds even if migration fails
- [x] `session` accessible in Rodauth context — it is, directly. No
      `scope.session` needed; the issue flagged this as unverified.

## Verification

Three specs, driving real signup through the form rather than the raw
insert `create_account_direct` does, since the point is the Rodauth hook:

| Spec | On parent commit |
|---|---|
| copies the credentials onto the new account | **fails** — connection not migrated |
| still creates the account when the migration raises | passes (regression guard) |
| leaves accounts without session credentials alone | passes (regression guard) |

- 312 specs, 1 failure: `error_states_spec:162`, which fails identically
  on a clean tree — it needs a real `GOODREADS_API_KEY` and I ran without
  a local `.env`. System and OverDrive specs excluded.
- RuboCop clean across 86 files.