### PR TITLE
Run the OverDrive availability check over a WebSocket

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -132,6 +132,10 @@ class App < Roda
     r.on 'ws', 'bookmooch', String do |session_id|
       r.websocket { |connection| Websockets.handle_bookmooch(connection, session_id) }
     end
+    # route: WebSocket /ws/availability/:session_id
+    r.on 'ws', 'availability', String do |session_id|
+      r.websocket { |connection| Websockets.handle_availability(connection, session_id) }
+    end
     r.get('import-status') { import_status.to_json } # route: GET /import-status
 
     # route: GET /nearest-zip?lat=34.09&lon=-118.40
@@ -286,18 +290,27 @@ class App < Roda
                 flash[:error] = 'Invalid library selection'
                 r.redirect "/goodreads/shelves/#{@shelf_name}/overdrive"
               end
-              overdrive = Overdrive.new(@book_info, consortium)
-              titles = overdrive.fetch_titles_availability
-              Cache.set(session, titles:, collection_token: overdrive.collection_token, website_id: overdrive.website_id, library_url: overdrive.library_url)
-              r.redirect '/goodreads/availability'
+              # The OverDrive check does not fit in a request (#1347), so hand it
+              # to the WebSocket and send the browser somewhere that can wait.
+              queue_availability_check @book_info, consortium
+              r.redirect '/goodreads/availability/progress'
             end
           end
         end
       end
 
-      r.is 'availability' do
+      r.on 'availability' do
         require_goodreads r
-        r.get do # route: GET /goodreads/availability
+
+        # route: GET /goodreads/availability/progress
+        r.get 'progress' do
+          @session_id = session['session_id']
+          @results_path = '/goodreads/availability'
+          @retry_path = '/libraries'
+          view 'availability_progress'
+        end
+
+        r.get true do # route: GET /goodreads/availability
           load_cached_availability
           unless @titles
             # Resume at the furthest step already completed rather than sending

--- a/lib/availability_helpers.rb
+++ b/lib/availability_helpers.rb
@@ -5,6 +5,18 @@
 # only where an incomplete flow sends the visitor back to differs, so that
 # stays with each route.
 module AvailabilityHelpers
+  # Hand the OverDrive check to the WebSocket rather than running it inline.
+  # RequestTimeout caps a request at 25s to stay under Render's proxy, and a
+  # large shelf takes longer than that (#1347); the middleware exempts WebSocket
+  # upgrades, so that is where the work can actually finish.
+  #
+  # Any titles from a previous library are cleared first, so the progress page
+  # cannot redirect to stale results if this run fails.
+  def queue_availability_check book_info, consortium
+    Cache.set(session, titles: nil)
+    Cache.set(session, availability_book_info: book_info, availability_consortium: consortium)
+  end
+
   def load_cached_availability
     @titles = Cache.get session, :titles
     @collection_token = Cache.get session, :collection_token

--- a/lib/cache.rb
+++ b/lib/cache.rb
@@ -14,13 +14,28 @@ module Cache
   module_function
 
   def set session, **pairs
-    pairs.each do |key, value|
-      CACHE["#{session['session_id']}/#{key}"] = value
-    end
+    set_in_session session['session_id'], **pairs
   end
 
   def get session, key
-    CACHE["#{session['session_id']}/#{key}"]
+    get_in_session session['session_id'], key
+  end
+
+  # Same in-memory store as `set`/`get`, for callers holding a session id rather
+  # than the session itself -- WebSocket handlers never see the Rack session.
+  #
+  # Deliberately not `set_by_id`, which serialises through JSON on disk. The
+  # availability titles are objects the view calls methods on, and a JSON round
+  # trip would hand it bare hashes. Nothing here touches the filesystem, so
+  # OAuth tokens stored this way stay in memory.
+  def set_in_session session_id, **pairs
+    pairs.each do |key, value|
+      CACHE["#{session_id}/#{key}"] = value
+    end
+  end
+
+  def get_in_session session_id, key
+    CACHE["#{session_id}/#{key}"]
   end
 
   # Set cache values by session ID using shared filesystem (cross-process)

--- a/lib/overdrive.rb
+++ b/lib/overdrive.rb
@@ -98,17 +98,27 @@ class Overdrive
     body['collectionToken']
   end
 
-  def fetch_titles_availability
+  # The optional block is called after each chunk lands, so a caller streaming
+  # to a browser has something to show. Chunks are the only honest unit of
+  # progress here: within one, the OverDrive search, edition expansion and
+  # availability lookup all run concurrently and finish out of order.
+  def fetch_titles_availability &progress_callback
     total_start = monotonic_now
     rss_before = self.class.rss_mb
     chunks = @book_info.each_slice(CHUNK_SIZE).to_a
     warn "[overdrive] Starting: #{@book_info.size} books in #{chunks.size} chunks, RSS=#{rss_before.round(1)}MB"
 
     results = Array.new(chunks.size)
+    completed = 0
     task = Async do
       barrier = Async::Barrier.new
       chunks.each_with_index do |chunk, i|
-        barrier.async { results[i] = process_chunk(chunk, i + 1, chunks.size) }
+        barrier.async do
+          results[i] = process_chunk(chunk, i + 1, chunks.size)
+          # Fibers on one thread, so this increment needs no lock.
+          completed += 1
+          report_chunk_progress(progress_callback, completed, chunks.size)
+        end
       end
       barrier.wait
     ensure
@@ -124,6 +134,14 @@ class Overdrive
   private
 
   def monotonic_now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+  # A failure to report progress must never lose the availability results the
+  # chunk just produced -- the socket may have closed while this ran.
+  def report_chunk_progress callback, completed, total
+    callback&.call(type: 'progress', message: "Checking availability — #{completed} of #{total} batches complete...", current: completed, total: total)
+  rescue StandardError
+    nil
+  end
 
   def process_chunk chunk, chunk_num, chunk_count
     start = monotonic_now

--- a/lib/search_routes.rb
+++ b/lib/search_routes.rb
@@ -81,8 +81,18 @@ module SearchRoutes
         request.redirect '/search/shelves'
       end
 
-      cache_anonymous_availability request, book_info, consortium
-      request.redirect '/search/availability'
+      # Same reason as the authenticated twin: the OverDrive check does not fit
+      # in a request (#1347), so the WebSocket runs it.
+      queue_availability_check book_info, consortium
+      request.redirect '/search/availability/progress'
+    end
+
+    # route: GET /search/availability/progress
+    request.get 'progress' do
+      @session_id = session['session_id']
+      @results_path = '/search/availability'
+      @retry_path = '/search/library'
+      view 'availability_progress'
     end
 
     # route: GET /search/availability
@@ -101,18 +111,6 @@ module SearchRoutes
       @library_action = '/search/library'
       view 'availability'
     end
-  end
-
-  # Kept out of the route block so the rescue covers the OverDrive calls and
-  # nothing else -- wrapping the whole block would swallow the CSRF rejection,
-  # which has to reach the app's handler.
-  def cache_anonymous_availability request, book_info, consortium
-    overdrive = Overdrive.new(book_info, consortium)
-    titles = overdrive.fetch_titles_availability
-    Cache.set(session, titles:, collection_token: overdrive.collection_token, website_id: overdrive.website_id, library_url: overdrive.library_url)
-  rescue Overdrive::ApiError => e
-    Sentry.capture_exception(e) if defined?(Sentry)
-    reject_library request, 'We could not reach OverDrive for that library. Please try another.'
   end
 
   def anonymous_shelf_books

--- a/lib/websockets.rb
+++ b/lib/websockets.rb
@@ -2,6 +2,7 @@
 
 require_relative 'bookmooch'
 require_relative 'cache'
+require_relative 'overdrive'
 
 # WebSocket handlers for real-time updates
 module Websockets
@@ -31,6 +32,64 @@ module Websockets
   rescue StandardError => e
     Sentry.capture_exception(e) if defined?(Sentry)
     write_error(connection, "An error occurred: #{e.message}")
+    connection.close
+  end
+
+  # Handle the OverDrive availability check via WebSocket with progress updates.
+  #
+  # This exists because the work does not fit in a request. RequestTimeout caps
+  # requests at 25s to stay under Render's proxy, and a large shelf takes longer
+  # than that against OverDrive (#1347). The middleware skips WebSocket
+  # upgrades, so running it here is what makes the slow path possible at all.
+  def handle_availability connection, session_id
+    connection.write({type: 'connected', message: 'WebSocket connected'}.to_json)
+    connection.flush
+
+    book_info = Cache.get_in_session(session_id, :availability_book_info)
+    consortium = Cache.get_in_session(session_id, :availability_consortium)
+
+    unless book_info && consortium
+      write_error(connection, 'Missing job parameters')
+      connection.close
+      return
+    end
+
+    run_availability(connection, session_id, book_info, consortium)
+  rescue StandardError => e
+    # Everything in here is OverDrive work, so the message names OverDrive
+    # rather than leaking an exception string. Overdrive::ApiError is not
+    # caught separately: it belongs to the zip code library search, and nothing
+    # on this path raises it.
+    Sentry.capture_exception(e) if defined?(Sentry)
+    write_error(connection, 'We could not reach OverDrive for that library. Please try another.')
+    connection.close
+  end
+
+  def run_availability connection, session_id, book_info, consortium
+    closed = false
+    overdrive = Overdrive.new(book_info, consortium)
+    titles = overdrive.fetch_titles_availability do |progress|
+      next if closed
+
+      connection.write(progress.to_json)
+      connection.flush
+    rescue IOError
+      closed = true
+    end
+
+    # Cached whether or not the browser is still listening: they may have
+    # navigated away, and the results page reads from here either way.
+    Cache.set_in_session(
+      session_id,
+      titles:,
+      collection_token: overdrive.collection_token,
+      website_id: overdrive.website_id,
+      library_url: overdrive.library_url
+    )
+    return if closed
+
+    connection.write({type: 'complete', message: "Found #{titles.size} titles.", titles_count: titles.size}.to_json)
+    connection.flush
     connection.close
   end
 

--- a/spec/lib/availability_job_spec.rb
+++ b/spec/lib/availability_job_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+require 'cache'
+require 'json'
+require 'overdrive'
+require 'websockets'
+
+# Records what a WebSocket handler wrote, so the handler can be exercised
+# without a socket.
+class FakeConnection
+  attr_reader :messages
+
+  def initialize
+    @messages = []
+    @closed = false
+  end
+
+  def write(payload) = @messages << JSON.parse(payload)
+
+  def flush = nil
+
+  def close = @closed = true
+
+  def closed? = @closed
+
+  def types = @messages.map { |m| m['type'] }
+end
+
+describe 'availability job' do
+  describe 'Cache session-id accessors' do
+    # set_by_id round trips through JSON on disk, which would turn the titles
+    # into bare hashes. The availability view calls methods on them.
+    it 'keeps objects intact, unlike the filesystem cache' do
+      title = Struct.new(:copies_available).new(3)
+      Cache.set_in_session 'session-objects', titles: [title]
+
+      assert_equal 3, Cache.get_in_session('session-objects', :titles).first.copies_available
+    end
+
+    it 'reads back what the session-keyed writer stored' do
+      Cache.set_in_session 'session-shared', availability_consortium: 1047
+
+      assert_equal 1047, Cache.get_in_session('session-shared', :availability_consortium)
+    end
+  end
+
+  describe 'Websockets.handle_availability' do
+    it 'reports missing parameters instead of hanging the page' do
+      connection = FakeConnection.new
+      Websockets.handle_availability connection, 'session-with-nothing-cached'
+
+      assert_equal %w[connected error], connection.types
+      assert_equal 'Missing job parameters', connection.messages.last['message']
+      assert connection.closed?, 'the socket was left open'
+    end
+
+    # The page shows a spinner until the socket says otherwise, so a crash that
+    # writes nothing would spin forever.
+    it 'reports an OverDrive failure rather than leaving the page spinning' do
+      Cache.set_in_session 'session-overdrive-down', availability_book_info: [{title: 'A'}], availability_consortium: 1047
+      connection = FakeConnection.new
+
+      Overdrive.stub(:new, ->(*) { raise 'OverDrive is unreachable' }) do
+        Websockets.handle_availability connection, 'session-overdrive-down'
+      end
+
+      assert_equal 'error', connection.types.last
+      assert_includes connection.messages.last['message'], 'OverDrive'
+      assert connection.closed?, 'the socket was left open'
+    end
+  end
+
+  describe 'Overdrive#fetch_titles_availability progress' do
+    # Skips initialize, which reaches OverDrive for a token before it does
+    # anything else.
+    def overdrive_over books
+      overdrive = Overdrive.allocate
+      overdrive.instance_variable_set :@book_info, books
+      overdrive.instance_variable_set :@timings, {}
+      overdrive.define_singleton_method(:process_chunk) { |_chunk, _num, _count| [] }
+      overdrive
+    end
+
+    it 'reports once per chunk, ending at the chunk count' do
+      chunks = 3
+      overdrive = overdrive_over Array.new(chunks * Overdrive::CHUNK_SIZE) { |i| {title: "Book #{i}"} }
+
+      updates = []
+      overdrive.fetch_titles_availability { |update| updates << update }
+
+      assert_equal chunks, updates.size
+      assert_equal((1..chunks).to_a, updates.map { |u| u[:current] })
+      assert(updates.all? { |u| u[:total] == chunks }, 'every update should carry the chunk count')
+    end
+
+    it 'still returns results when the callback raises' do
+      overdrive = overdrive_over [{title: 'Only book'}]
+
+      results = overdrive.fetch_titles_availability { raise IOError, 'browser went away' }
+
+      assert_empty results
+    end
+
+    it 'works with no callback at all' do
+      overdrive = overdrive_over [{title: 'Only book'}]
+
+      assert_empty overdrive.fetch_titles_availability
+    end
+  end
+end

--- a/spec/web/anonymous_search_spec.rb
+++ b/spec/web/anonymous_search_spec.rb
@@ -149,6 +149,27 @@ describe 'Anonymous search flow' do
     end
   end
 
+  # #1347: the OverDrive check is handed to a WebSocket because it does not fit
+  # inside RequestTimeout's 25s budget. The progress page is what the browser
+  # waits on while that runs.
+  describe 'GET /search/availability/progress' do
+    it 'redirects to / when no session credentials exist' do
+      visit '/search/availability/progress'
+
+      assert_current_path '/'
+    end
+
+    it 'points the socket and the results link at the anonymous flow' do
+      with_anonymous_session do
+        get '/search/availability/progress'
+
+        assert_equal 200, last_response.status
+        assert_includes last_response.body, '/ws/availability/'
+        assert_includes last_response.body, "resultsPath = '/search/availability'"
+      end
+    end
+  end
+
   describe 'POST /search/availability' do
     it 'redirects to / when no session credentials exist' do
       post '/search/availability', 'consortium' => '1047'

--- a/spec/web/error_states_spec.rb
+++ b/spec/web/error_states_spec.rb
@@ -161,4 +161,15 @@ describe 'Error states' do
     visit '/goodreads/availability'
     assert_text 'Please choose a shelf first'
   end
+
+  # #1347: the OverDrive check moved to a WebSocket because it does not fit in
+  # RequestTimeout's 25s budget. This page is what the browser waits on, so it
+  # has to render without any titles cached -- there are none until the socket
+  # finishes.
+  it 'renders the availability progress page before any titles exist' do
+    seed_goodreads_user
+    visit '/goodreads/availability/progress'
+
+    assert_text 'Checking Library Availability'
+  end
 end

--- a/views/availability_progress.erb
+++ b/views/availability_progress.erb
@@ -1,0 +1,101 @@
+<% content_for :title, "Checking Library Availability" %>
+<% content_for :description, "Checking which of your books are available at your library. Please wait while we search." %>
+
+<div class="max-w-4xl mx-auto mb-8 mt-16">
+  <div class="text-center">
+    <h3 class="font-display text-2xl font-medium text-mauve-950 mb-4">Checking Library Availability</h3>
+
+    <!-- Animated spinner -->
+    <div class="flex justify-center mb-6">
+      <div class="relative">
+        <div id="availability-spinner" class="w-20 h-20 border-4 border-mauve-200 border-t-mauve-950 rounded-full animate-spin"></div>
+        <div class="absolute inset-0 flex items-center justify-center">
+          <svg class="w-8 h-8 text-mauve-950" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+          </svg>
+        </div>
+      </div>
+    </div>
+
+    <p class="text-mauve-700 mb-2" id="status-message">Connecting...</p>
+    <p class="text-sm text-mauve-500" id="progress-text"></p>
+
+    <div id="error-message" class="hidden mt-4 p-4 rounded-xl bg-mauve-950/[.025] border border-mauve-300 text-mauve-950"></div>
+    <%# No display utility besides `hidden` here: `hidden` and `inline-flex` carry
+        the same specificity, Tailwind emits `.inline-flex` after `.hidden`, and the
+        later rule wins -- pairing them leaves the button on screen throughout a
+        healthy run. showError adds `inline-flex` when it drops `hidden`. %>
+    <a id="retry-button" href="<%= @retry_path %>" class="hidden mt-6 items-center justify-center px-6 py-3 bg-gradient-to-r from-indigo-800 to-violet-800 text-white font-medium rounded-full shadow-md hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300">Try a different library</a>
+  </div>
+</div>
+
+<script>
+(function() {
+  const sessionId = '<%= @session_id %>';
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const wsUrl = `${protocol}//${window.location.host}/ws/availability/${sessionId}`;
+  const resultsPath = '<%= @results_path %>';
+
+  const statusMessage = document.getElementById('status-message');
+  const progressText = document.getElementById('progress-text');
+  const errorMessage = document.getElementById('error-message');
+  const retryButton = document.getElementById('retry-button');
+  // By id, not '.animate-spin': the import toast can render above this page's
+  // content, so a document-wide query would stop the toast's spinner instead.
+  const spinner = document.getElementById('availability-spinner');
+
+  function showError(message) {
+    errorMessage.textContent = message;
+    errorMessage.classList.remove('hidden');
+    retryButton.classList.remove('hidden');
+    retryButton.classList.add('inline-flex');
+    spinner.style.display = 'none';
+  }
+
+  const ws = new WebSocket(wsUrl);
+
+  ws.onopen = function() {
+    statusMessage.textContent = 'Searching your library...';
+  };
+
+  ws.onmessage = function(event) {
+    const data = JSON.parse(event.data);
+
+    switch(data.type) {
+      case 'connected':
+        statusMessage.textContent = 'Connected! Searching your library...';
+        break;
+
+      case 'status':
+        statusMessage.textContent = data.message;
+        progressText.textContent = '';
+        break;
+
+      case 'progress':
+        statusMessage.textContent = data.message;
+        if (data.total && data.current) {
+          progressText.textContent = `${data.total - data.current} batches remaining`;
+        }
+        break;
+
+      case 'complete':
+        statusMessage.textContent = data.message;
+        progressText.textContent = 'Done!';
+        setTimeout(function() {
+          window.location.href = resultsPath;
+        }, 1000);
+        break;
+
+      case 'error':
+        showError(data.message);
+        statusMessage.textContent = 'An error occurred';
+        break;
+    }
+  };
+
+  ws.onerror = function() {
+    showError('Connection error. Please try again.');
+    statusMessage.textContent = 'Connection failed';
+  };
+})();
+</script>


### PR DESCRIPTION
Closes #1347.

## What was wrong

`POST /goodreads/shelves/:id/overdrive` ran the entire availability check
inline. On a large shelf that exceeds the 25s cap in
`lib/request_timeout.rb`, which is the Sentry error on the issue.

Two things that look like fixes are not:

**Raising the timeout.** The 25s is chosen to stay under Render's ~30s
proxy timeout, so the app can report to Sentry rather than 502 silently.
Raising it trades a reported error for an unreported one.

**Adding Async.** `fetch_titles_availability` was already concurrent —
chunks of 100 under an `Async::Barrier`, with a semaphore of 16 inside.
There was simply more work than fits in the budget.

## The change

The work leaves the request, following the path BookMooch imports
already take:

| Step | Before | After |
|---|---|---|
| POST | fetch shelf, run OverDrive, redirect | fetch shelf, cache job, redirect |
| Progress page | — | `GET .../availability/progress` |
| The slow part | in the request | `/ws/availability/:session_id` |
| Results | `GET /goodreads/availability` | unchanged |

`RequestTimeout` skips WebSocket upgrades by design (`websocket?`), which
is what makes the slow path possible at all.

## Details worth review

**Progress is per chunk.** Within a chunk the search, edition expansion
and availability lookup run concurrently and finish out of order, so the
chunk is the only unit that can be counted honestly. `completed += 1`
needs no lock — these are fibers on one thread.

**Results cache via `Cache.set_in_session`, not `set_by_id`.** The latter
serialises through JSON on disk, and `availability.erb` calls methods on
the titles, so a round trip would hand it bare hashes. The new accessor
uses the same in-memory TupleSpace as `Cache.set`, keyed by session id
for callers that never see the Rack session. This preserves exactly the
in-memory-only property the inline version had — no new persistence, and
nothing written to disk.

**Titles are cleared when a check is queued**, so the progress page
cannot redirect to a previous library's results if this run fails.

**Results are cached even if the socket closed.** The visitor may have
navigated away; the results page reads from the cache either way.

**`Overdrive::ApiError` is not caught separately** in the handler. It
belongs to the zip-code library search and nothing on this path raises
it, so catching it would have been decoration.

**The anonymous twin from #1348 had the same exposure** and gets the same
treatment, sharing `availability_progress.erb` and
`queue_availability_check`.

**The new view keeps `hidden` unpaired** with a display utility — the
#1344 bug. `spec/lib/view_display_classes_spec.rb` passes.

## Known limit

The POST still calls `fetch_shelf_blocking`. That is normally a cache hit
(the shelf page or background import warms it), but it blocks when cold.
It is a much smaller window than the OverDrive call and moving it needs
the Goodreads token available to the socket, so I have left it for its
own change rather than widening this one.

## Verification

7 new specs in `spec/lib/availability_job_spec.rb` covering the cache
accessors, the handler's two failure paths, and the progress callback
(including a callback that raises, and no callback at all). Confirmed
failing with the implementation reverted and specs kept.

Plus 3 route specs: the anonymous progress page's socket URL and results
path, its credential guard, and an authenticated spec asserting the page
renders before any titles exist — which is the state it always loads in.

- 322 specs, 1 failure: `error_states_spec:162`, which fails identically
  on a clean tree — it needs a real `GOODREADS_API_KEY` and I ran without
  a local `.env`. System and OverDrive specs excluded.
- RuboCop clean across 87 files.

The happy path needs live OverDrive credentials and a browser, so it is
not covered here.