### PR TITLE
Serve the search interface from the root route

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -122,9 +122,15 @@ class App < Roda
     # Serve homepage early with no session writes or Sentry enrichment.
     # Bots/monitors hit / every minute; skipping these avoids per-request
     # allocations that fragment glibc malloc arenas and grow RSS toward OOM.
-    r.root do # route: GET /
-      view 'welcome'
-    end
+    #
+    # Everything here only reads. `goodreads_session_present?` looks the
+    # credentials up without assigning a session id, and no request token is
+    # fetched -- that would write to the cache under a key derived from an id
+    # that does not exist yet, which every visitor would share. /connect does it
+    # on click instead, from a route that runs after the id is assigned.
+    #
+    # welcome.erb is kept but no longer routed to.
+    r.root { root_response(r) } # route: GET /
 
     enrich_sentry(r)
     session['session_id'] ||= SecureRandom.uuid
@@ -137,6 +143,10 @@ class App < Roda
       r.websocket { |connection| Websockets.handle_availability(connection, session_id) }
     end
     r.get('import-status') { import_status.to_json } # route: GET /import-status
+
+    # Sits here, after the session id is assigned, because caching a request
+    # token keys on that id.
+    r.get('connect') { redirect_to_goodreads_authorization(r) } # route: GET /connect
 
     # route: GET /nearest-zip?lat=34.09&lon=-118.40
     r.get 'nearest-zip' do

--- a/lib/oauth_helpers.rb
+++ b/lib/oauth_helpers.rb
@@ -10,6 +10,26 @@ module OauthHelpers
     request.redirect '/'
   end
 
+  # The homepage's Goodreads button. Kept off `/` because caching a request
+  # token keys on the session id, which the root route deliberately does not
+  # assign -- see the comment there.
+  #
+  # fetch_and_cache_request_token swallows failures and returns nil, so the
+  # fallback keeps a dead Goodreads from redirecting the visitor to nowhere.
+  def redirect_to_goodreads_authorization request
+    request_token = fetch_and_cache_request_token
+    request.redirect request_token&.authorize_url || '/'
+  end
+
+  # Anonymous visitors go straight to their shelves; signed-in ones to their
+  # home page. Everyone else gets the search interface. All reads -- nothing
+  # here may write to the session.
+  def root_response request
+    request.redirect '/home' if @user
+    request.redirect '/search/shelves' if goodreads_session_present?
+    view 'search'
+  end
+
   def handle_anonymous_oauth_callback request, request_token
     credentials = Goodreads.exchange_token(request_token)
     store_goodreads_in_session(credentials)

--- a/spec/web/root_route_spec.rb
+++ b/spec/web/root_route_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+ROOT_ANON_CREDENTIALS = {anon_goodreads_user_id: '7', anon_goodreads_token: 'token', anon_goodreads_secret: 'secret'}.freeze
+
+describe 'root route' do
+  include Capybara::DSL
+  include Minitest::Capybara::Behaviour
+  include Rack::Test::Methods
+
+  let(:app) { App }
+
+  def with_goodreads_session(&)
+    Cache.stub(:get, ->(_session, key) { ROOT_ANON_CREDENTIALS[key] }) do
+      Auth.stub(:rebuild_access_token, Object.new, &)
+    end
+  end
+
+  describe 'GET /' do
+    it 'serves the search interface to a new visitor' do
+      get '/'
+
+      assert_equal 200, last_response.status
+      assert_includes last_response.body, 'href="/connect"'
+    end
+
+    # The OOM work moved r.root ahead of the session write so bot traffic stops
+    # allocating a cookie per request. Serving a different view here must not
+    # quietly undo that: the README names it as a primary fix.
+    it 'writes no session cookie' do
+      get '/'
+
+      cookie = last_response.headers.keys.find { |key| key.casecmp('set-cookie').zero? }
+
+      assert_nil cookie, 'the homepage wrote a session cookie'
+    end
+
+    it 'sends a visitor who already connected Goodreads to their shelves' do
+      with_goodreads_session do
+        get '/'
+
+        assert_equal '/search/shelves', last_response.headers['location']
+      end
+    end
+
+    it 'sends a logged-in user to their home page' do
+      email, password = create_account_direct
+      password_login(email, password)
+      visit '/'
+
+      assert_current_path '/home'
+    end
+  end
+
+  describe 'GET /connect' do
+    it 'redirects to the Goodreads authorize url' do
+      token = Struct.new(:authorize_url).new('https://www.goodreads.com/oauth/authorize?oauth_token=abc')
+
+      Auth.stub(:fetch_request_token, token) do
+        get '/connect'
+
+        assert_equal token.authorize_url, last_response.headers['location']
+      end
+    end
+
+    # fetch_and_cache_request_token swallows the failure and returns nil, so
+    # without a fallback this would redirect to nowhere.
+    it 'sends the visitor back to the homepage when Goodreads is unreachable' do
+      Auth.stub(:fetch_request_token, ->(*) { raise 'Goodreads is unreachable' }) do
+        get '/connect'
+
+        assert_equal '/', last_response.headers['location']
+      end
+    end
+  end
+end

--- a/spec/web/system_spec.rb
+++ b/spec/web/system_spec.rb
@@ -79,9 +79,10 @@ describe App do
     visit '/logout'
     click_button 'Log Out' # Confirm logout
 
-    # Should be back on the welcome page
+    # Should be back on the search homepage. It replaced welcome.erb at / in
+    # #1267, so this no longer asserts that page's "Create Your Account".
     assert_text 'Log in'
-    assert_text 'Create Your Account'
+    assert_text 'Connect with Goodreads'
 
     # Test login with the same credentials
     click_link 'Log in'


### PR DESCRIPTION
Closes #1267. **Stacked on #1352** — based on `search-homepage-view`,
which adds the view this route renders. GitHub retargets this to `main`
when that merges.

## Behaviour

| Visitor | Goes to |
|---|---|
| Signed in | `/home` |
| Anonymous, Goodreads already connected | `/search/shelves` |
| Everyone else | `search.erb` |

`welcome.erb` is kept but no longer routed to.

## The constraint this had to work around

Per the discussion on the issue, wiring `@auth_url` at `/` is not safe.
`r.root` sits ahead of the session write on purpose — the README names
that as a primary OOM fix on a 512MB instance that was being OOM-killed
daily. Fetching a request token there would:

- cache it under `"/request_token"`, since the session id does not exist
  yet — **one key shared by every concurrent visitor**; or
- force a session id, putting a `Set-Cookie` on every bot request, which
  is the exact allocation the OOM work removed.

So the root route only reads. `goodreads_session_present?` looks the
credentials up without assigning an id, and `GET /connect` fetches the
token on click from a route that runs after the id exists. #1267 already
asked for this timing:

> `fetch_and_cache_request_token` only called when needed

`/connect` falls back to `/` when the fetch fails, since
`fetch_and_cache_request_token` swallows the error and returns nil.

## Things worth knowing

**A spec pins the no-cookie property.** It passes on the parent commit
too — it is a regression guard, not a fix. Nothing else in the suite
would notice that mitigation being undone.

**Both route bodies moved to `OauthHelpers`.** The main route block was
one line under `Metrics/BlockLength` before this; inlining them broke it.

**`system_spec` needed updating.** After logout it asserted
`Create Your Account`, which only exists on `welcome.erb`. It now asserts
`Connect with Goodreads`. Worth flagging because `system_spec` is
excluded from my local runs (browser + live APIs) — CI is the first place
that assertion actually executes.

**The analytics criterion is dropped.** #1267 asked to rename an event
from `page: 'welcome'` to `page: 'search'`; PostHog was removed in #1346,
so there is no event. Noted on the issue.

## Verification

6 new specs; 5 confirmed failing before the routes existed, the 6th being
the no-cookie guard described above.

- 336 specs, 1 failure: `error_states_spec:162`, which fails identically
  on a clean tree — it needs a real `GOODREADS_API_KEY` and I ran without
  a local `.env`.
- RuboCop clean across 89 files.